### PR TITLE
fix: eliminate transparent flash and double-box on splash screen

### DIFF
--- a/splash.html
+++ b/splash.html
@@ -6,8 +6,9 @@
     <title>PulseSQL Splash</title>
     <style>
       html,
-      body {
-        height: 100%;
+      body,
+      #root {
+        background: transparent !important;
       }
 
       body {
@@ -16,15 +17,10 @@
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        background: transparent;
       }
 
       #root {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: auto;
-        height: auto;
+        display: contents;
       }
     </style>
     <script type="module" src="/src/splash.tsx"></script>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,7 +154,7 @@ fn create_splash_window(app: &AppHandle) -> Result<(), String> {
         WebviewUrl::App("splash.html".into()),
     )
         .title("PulseSQL")
-        .inner_size(306.0, 264.0)
+        .inner_size(490.0, 420.0)
         .resizable(false)
         .maximizable(false)
         .minimizable(false)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ fn create_splash_window(app: &AppHandle) -> Result<(), String> {
         .minimizable(false)
         .closable(false)
         .decorations(false)
+        .shadow(false)
         .center()
         .visible(false)
         .always_on_top(true)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,17 @@ fn reveal_main_window(
 }
 
 #[tauri::command]
+fn show_splash_window(app: AppHandle) -> Result<(), String> {
+    if let Some(splash_window) = app.get_webview_window(SPLASH_WINDOW_LABEL) {
+        splash_window
+            .show()
+            .map_err(|error| format!("Failed to show splash window: {error}"))?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 fn close_splash_window(app: AppHandle) -> Result<(), String> {
     if let Some(splash_window) = app.get_webview_window(SPLASH_WINDOW_LABEL) {
         splash_window
@@ -239,7 +250,7 @@ pub fn run() {
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(std::time::Duration::from_secs(4)).await;
                     let splash_state = app_handle.state::<Mutex<SplashState>>();
-                    let _ = finalize_startup(&app_handle, &splash_state, false);
+                    let _ = finalize_startup(&app_handle, &splash_state, true);
                 });
             }
 
@@ -253,6 +264,7 @@ pub fn run() {
             greet,
             update_splash_progress,
             reveal_main_window,
+            show_splash_window,
             close_splash_window,
             get_splash_state,
             reopen_splash_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,7 +150,7 @@ fn create_splash_window(app: &AppHandle) -> Result<(), String> {
         .closable(false)
         .decorations(false)
         .center()
-        .visible(true)
+        .visible(false)
         .always_on_top(true)
         .transparent(true);
 

--- a/src/SplashScreen.tsx
+++ b/src/SplashScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
-import { getCurrentWindow } from '@tauri-apps/api/window';
 import brandLogo from './assets/pulsesql-logo.svg';
 import { getInitialLocale, translate } from './i18n';
 import { LOCK_SPLASH_FOR_DEV } from './devFlags';
@@ -22,7 +21,7 @@ export default function SplashScreen() {
   const normalizedProgress = useMemo(() => Math.max(0, Math.min(progress, 100)), [progress]);
 
   useEffect(() => {
-    void getCurrentWindow().show().catch(() => null);
+    void invoke('show_splash_window').catch(() => null);
   }, []);
 
   useEffect(() => {

--- a/src/SplashScreen.tsx
+++ b/src/SplashScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import brandLogo from './assets/pulsesql-logo.svg';
 import { getInitialLocale, translate } from './i18n';
 import { LOCK_SPLASH_FOR_DEV } from './devFlags';
@@ -19,6 +20,10 @@ export default function SplashScreen() {
   const [finishing, setFinishing] = useState(false);
 
   const normalizedProgress = useMemo(() => Math.max(0, Math.min(progress, 100)), [progress]);
+
+  useEffect(() => {
+    void getCurrentWindow().show().catch(() => null);
+  }, []);
 
   useEffect(() => {
     if (LOCK_SPLASH_FOR_DEV) {

--- a/src/index.css
+++ b/src/index.css
@@ -40,9 +40,7 @@
 
   html[data-splash='true'],
   body[data-splash='true'] {
-    background:
-      radial-gradient(circle at top center, rgba(43, 211, 201, 0.12), transparent 34%),
-      linear-gradient(180deg, #0d1218 0%, #0b0f14 52%, #090d11 100%);
+    background: transparent;
   }
 
   body[data-splash='true'] {

--- a/src/index.css
+++ b/src/index.css
@@ -38,20 +38,6 @@
     background: var(--bt-body-background);
   }
 
-  html[data-splash='true'],
-  body[data-splash='true'] {
-    background: transparent;
-  }
-
-  body[data-splash='true'] {
-    min-height: 100vh;
-    margin: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-  }
-
   body[data-splash='true'] #root {
     width: auto;
     height: auto;


### PR DESCRIPTION
## Summary

Fixes #28 and #29 — splash screen appearance issues on macOS.

- **#29** — Splash window starts hidden (`visible: false`) and is revealed via a custom Rust command (`show_splash_window`) invoked after React's first paint. This ensures the window only appears once content is rendered, eliminating the blank/transparent flash before JS loads.
- **#28** — Multiple layers of fixes to remove the outer rectangular box and leave only the rounded card visible:
  - `background: transparent !important` forced on `html, body, #root` in `splash.html` (unlayered CSS beats `@layer base` from Tailwind/index.css)
  - Splash window enlarged from 306×264 → 490×420 so the card's `box-shadow` glows (up to 80px spread) have room to fade instead of being clipped flush against the window edge
  - `.shadow(false)` on the window builder removes the macOS native drop shadow that was rendering as a dark outline around the glow

**Bonus:** main window now comes to the foreground on startup — the auto-timer path was calling `finalize_startup` with `focus_main: false`, so `set_focus()` was never called.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/lib.rs` | `visible(false)` + new `show_splash_window` command + `shadow(false)` + window 490×420 + `focus_main: true` in timer |
| `src/SplashScreen.tsx` | `useEffect` calls `invoke('show_splash_window')` after first mount |
| `splash.html` | `background: transparent !important` on `html, body, #root`; `#root` → `display: contents` |
| `src/index.css` | Removed redundant `@layer base` splash background rules (unlayered `splash.html` styles take precedence) |

## Test plan

- [ ] Launch app — splash appears already populated, no blank frame flash
- [ ] Only the rounded card is visible against the desktop — no outer box, no dark outline
- [ ] Splash closes and main window appears in the foreground (not minimized/behind other windows)

Closes #28, Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)