### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump for release v0.1.4.

**Changes since v0.1.3:**
- fix: splash screen transparent flash and double-box (#28, #29) — PR #31
- fix: input validation, shortcut logic, localStorage safety, filter debounce (#15, #16, #17, #23) — PR #32
- feat: main window opens maximized
- chore: unused_mut warning in cmd.rs