### PR TITLE
fix: Oracle Windows JDK compat + SSH keepalive (#25, #10)

### DIFF
--- a/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
+++ b/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
@@ -33,20 +33,31 @@ public class OracleJdbcRunner {
 
     try {
       switch (command) {
-        case "test" -> {
+        case "test":
           testConnection(request);
           writeSuccess(responsePath, "{\"message\":\"Connection successful\"}");
-        }
-        case "open" -> {
+          break;
+        case "open":
           testConnection(request);
           writeSuccess(responsePath, "{\"message\":\"Connection opened\"}");
-        }
-        case "listDatabases" -> writeSuccess(responsePath, listItems(request, "SELECT SYS_CONTEXT('USERENV', 'DB_NAME') AS DB_NAME FROM dual"));
-        case "listSchemas" -> writeSuccess(responsePath, listItems(request, "SELECT username FROM all_users WHERE username NOT IN ('SYS', 'SYSTEM') ORDER BY username"));
-        case "listTables" -> writeSuccess(responsePath, listItems(request, "SELECT table_name FROM all_tables WHERE owner = '" + escapeSql(request.schema) + "' ORDER BY table_name"));
-        case "listColumns" -> writeSuccess(responsePath, listColumns(request));
-        case "executeQuery" -> writeSuccess(responsePath, executeQuery(request));
-        default -> throw new IllegalArgumentException("Unsupported Oracle sidecar command: " + command);
+          break;
+        case "listDatabases":
+          writeSuccess(responsePath, listItems(request, "SELECT SYS_CONTEXT('USERENV', 'DB_NAME') AS DB_NAME FROM dual"));
+          break;
+        case "listSchemas":
+          writeSuccess(responsePath, listItems(request, "SELECT username FROM all_users WHERE username NOT IN ('SYS', 'SYSTEM') ORDER BY username"));
+          break;
+        case "listTables":
+          writeSuccess(responsePath, listItems(request, "SELECT table_name FROM all_tables WHERE owner = '" + escapeSql(request.schema) + "' ORDER BY table_name"));
+          break;
+        case "listColumns":
+          writeSuccess(responsePath, listColumns(request));
+          break;
+        case "executeQuery":
+          writeSuccess(responsePath, executeQuery(request));
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported Oracle sidecar command: " + command);
       }
     } catch (Exception error) {
       writeError(responsePath, error);

--- a/src-tauri/src/engines/oracle.rs
+++ b/src-tauri/src/engines/oracle.rs
@@ -478,6 +478,19 @@ fn humanize_oracle_sidecar_error(message: &str) -> String {
         .join(" ");
     }
 
+    // Java version too old to load ojdbc11 (requires Java 11+)
+    if lower.contains("unsupported class file major version")
+        || lower.contains("has been compiled by a more recent version")
+    {
+        return [
+            "Versao do Java incompativel com o driver Oracle (ojdbc11 requer Java 11+).",
+            "Use o botao 'Instalar JDK' para instalar o JDK Eclipse Temurin 21 automaticamente.",
+            "Detalhe tecnico:",
+            normalized,
+        ]
+        .join(" ");
+    }
+
     normalized.to_string()
 }
 

--- a/src-tauri/src/jdk.rs
+++ b/src-tauri/src/jdk.rs
@@ -6,11 +6,17 @@ use tauri::{AppHandle, Emitter};
 
 const JDK_DIR_NAME: &str = "jdk-bundled";
 
+/// Minimum Java major version required to compile and run the Oracle JDBC sidecar.
+/// - ojdbc11 requires Java 11+ at runtime.
+/// - OracleJdbcRunner.java uses Path.of / Files.readString which require Java 11+.
+const ORACLE_MIN_JAVA_VERSION: u32 = 11;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct JdkStatus {
     pub available: bool,
     pub version: Option<String>,
     pub source: String, // "bundled" | "system" | "none"
+    pub reason: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -63,6 +69,7 @@ pub fn detect_jdk(sidecar_root: &Path) -> JdkStatus {
             available: true,
             version: read_java_version(&bundled),
             source: "bundled".to_string(),
+            reason: None,
         };
     }
 
@@ -70,10 +77,18 @@ pub fn detect_jdk(sidecar_root: &Path) -> JdkStatus {
     // global PATH; javac lives in the JDK bin dir pointed to by JAVA_HOME.
     if let Some(javac) = java_home_exe("javac") {
         if let Some(java) = java_home_exe("java") {
+            let version = read_java_version(&java);
+            if let Some(ref v) = version {
+                let major = parse_java_major_version(v).unwrap_or(0);
+                if major < ORACLE_MIN_JAVA_VERSION {
+                    return jdk_version_too_old(v.clone());
+                }
+            }
             return JdkStatus {
                 available: true,
-                version: read_java_version(&java),
+                version,
                 source: "system".to_string(),
+                reason: None,
             };
         }
         let _ = javac; // JAVA_HOME has javac but no java — unusual, fall through
@@ -83,6 +98,11 @@ pub fn detect_jdk(sidecar_root: &Path) -> JdkStatus {
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             if let Some(version) = parse_java_version(&stderr) {
+                let major = parse_java_major_version(&version).unwrap_or(0);
+                if major < ORACLE_MIN_JAVA_VERSION {
+                    return jdk_version_too_old(version);
+                }
+
                 // Confirm javac is also reachable; otherwise it is a JRE, not a JDK.
                 let javac_ok = java_home_exe("javac").is_some()
                     || background("javac")
@@ -96,6 +116,7 @@ pub fn detect_jdk(sidecar_root: &Path) -> JdkStatus {
                         available: true,
                         version: Some(version),
                         source: "system".to_string(),
+                        reason: None,
                     };
                 }
             }
@@ -110,6 +131,31 @@ fn jdk_not_found() -> JdkStatus {
         available: false,
         version: None,
         source: "none".to_string(),
+        reason: None,
+    }
+}
+
+fn jdk_version_too_old(version: String) -> JdkStatus {
+    JdkStatus {
+        available: false,
+        version: Some(version.clone()),
+        source: "system".to_string(),
+        reason: Some(format!(
+            "Java {ORACLE_MIN_JAVA_VERSION}+ necessário (detectado: {version}). Instale o JDK 21 automaticamente."
+        )),
+    }
+}
+
+/// Extracts the Java major version from a version string.
+/// Handles both legacy format ("1.8.0_232" → 8) and modern format ("21.0.5" → 21).
+fn parse_java_major_version(version: &str) -> Option<u32> {
+    let mut parts = version.splitn(3, '.');
+    let first: u32 = parts.next()?.parse().ok()?;
+    if first == 1 {
+        // Legacy scheme: 1.X.Y → major is X
+        parts.next()?.parse().ok()
+    } else {
+        Some(first)
     }
 }
 

--- a/src-tauri/src/ssh/tunnel.rs
+++ b/src-tauri/src/ssh/tunnel.rs
@@ -113,9 +113,21 @@ pub fn start_ssh_tunnel(config: &ConnectionConfig) -> Result<SshTunnelHandle, St
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
 
     let join_handle = thread::spawn(move || {
+        let mut last_keepalive = std::time::Instant::now();
+
         loop {
             if stop_rx.try_recv().is_ok() {
                 break;
+            }
+
+            // libssh2 does not send keepalives automatically — the application must
+            // call keepalive_send() at the configured interval to prevent the SSH
+            // server (or intermediate NAT/firewall) from closing the idle connection.
+            if last_keepalive.elapsed().as_secs() >= SSH_KEEPALIVE_INTERVAL_SECS as u64 {
+                if let Err(error) = session.keepalive_send() {
+                    eprintln!("SSH keepalive failed: {error}");
+                }
+                last_keepalive = std::time::Instant::now();
             }
 
             match listener.accept() {

--- a/src/features/connections/JdkSetupBanner.tsx
+++ b/src/features/connections/JdkSetupBanner.tsx
@@ -7,6 +7,7 @@ interface JdkStatus {
   available: boolean;
   version: string | null;
   source: string;
+  reason: string | null;
 }
 
 interface JdkProgressPayload {
@@ -74,10 +75,13 @@ export default function JdkSetupBanner() {
       <div className="flex items-start gap-2.5">
         <AlertTriangle size={15} className="mt-0.5 shrink-0 text-amber-400" />
         <div className="flex-1 min-w-0">
-          <div className="font-medium text-amber-300 mb-0.5">Java/JDK nao encontrado</div>
+          <div className="font-medium text-amber-300 mb-0.5">
+            {status.reason ? 'Java incompativel' : 'Java/JDK nao encontrado'}
+          </div>
           <p className="text-xs text-amber-400/75 leading-relaxed">
-            Conexoes Oracle requerem Java. O PulseSQL pode baixar e instalar o JDK Eclipse
-            Temurin&nbsp;21 automaticamente.
+            {status.reason
+              ? status.reason
+              : 'Conexoes Oracle requerem Java. O PulseSQL pode baixar e instalar o JDK Eclipse Temurin\u00a021 automaticamente.'}
           </p>
 
           {installing ? (


### PR DESCRIPTION
## Summary

- **#25** — Oracle sidecar falhava no Windows com JDK 8 por três causas encadeadas:
  1. `OracleJdbcRunner.java` usava switch expressions (Java 14+), impossível compilar com JDK 8
  2. `detect_jdk` não validava versão mínima — reportava JDK 8 como "disponível" mesmo sem funcionar
  3. `ojdbc11` exige Java 11+ em runtime; JDK 8 falha ao carregar o driver

- **#10** — SSH tunnel caía silenciosamente em conexões ociosas porque `session.keepalive_send()` nunca era chamado — libssh2 não envia keepalives automaticamente, o app precisa chamar explicitamente a cada intervalo

## Mudanças

| Arquivo | Mudança |
|---|---|
| `OracleJdbcRunner.java` | Switch expression (Java 14+) → switch statement tradicional (Java 11+) |
| `jdk.rs` | `parse_java_major_version()` com suporte a formato legado `1.8.x`; `detect_jdk()` valida versão mínima Java 11; novo campo `reason` em `JdkStatus` |
| `oracle.rs` | Humaniza `UnsupportedClassVersionError` com mensagem clara de versão incompatível |
| `JdkSetupBanner.tsx` | Exibe `reason` quando JDK é muito antigo ("Java incompativel" em vez de "JDK nao encontrado") |
| `tunnel.rs` | Loop de accept chama `session.keepalive_send()` a cada 30s para manter a conexão SSH viva |

## Test plan

- [ ] Windows com JDK 8: banner mostra "Java incompativel — Java 11+ necessário (detectado: 1.8.x)" com botão de instalar JDK 21
- [ ] Windows sem JDK: banner mostra "JDK nao encontrado" com botão de instalar (comportamento anterior preservado)
- [ ] Windows/macOS com JDK 21: conexão Oracle funciona normalmente
- [ ] SSH: conexão permanece estável após período de idle superior a 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)