### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "pulsesql"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsesql"
-version = "0.1.3"
+version = "0.1.5"
 description = "PulseSQL desktop SQL workstation"
 authors = ["Saulo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump `tauri.conf.json` from `0.1.4` → `0.1.5`
- Bump `Cargo.toml` from `0.1.3` → `0.1.5` (was behind by two versions — PR #33 only bumped `tauri.conf.json`)
- Update `Cargo.lock` accordingly

## Context
The `v0.1.5` tag was created at the PR #34 commit, but neither file had been bumped. This caused the running build to embed version `0.1.4` in the binary. After this PR merges, delete the existing `v0.1.5` tag and recreate it at the new commit to trigger a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)