### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pulsesql",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "pulsesql"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsesql"
-version = "0.1.5"
+version = "0.1.6"
 description = "PulseSQL desktop SQL workstation"
 authors = ["Saulo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- `package.json`: `0.1.3` → `0.1.6` (was 3 versions behind)
- `src-tauri/tauri.conf.json`: `0.1.5` → `0.1.6`
- `src-tauri/Cargo.toml`: `0.1.5` → `0.1.6`
- `src-tauri/Cargo.lock`: updated accordingly

## Context
The v0.1.5 release ended up with mixed 0.1.4 and 0.1.5 artifacts in the same draft because two workflow runs targeted the same tag before the version bump was in place. Moving to 0.1.6 for a clean release. After this merges: create `v0.1.6` tag, publish release, then unpublish/delete the messy v0.1.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)