### PR TITLE
fix: publish tauri updater manifest

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm ci
 
       - name: Build and upload release artifacts
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -73,5 +73,7 @@ jobs:
           releaseBody: "Desktop builds for macOS (Apple Silicon + Intel), Windows, and Linux."
           releaseDraft: true
           prerelease: false
-          includeUpdaterJson: true
+          uploadUpdaterJson: true
+          uploadUpdaterSignatures: true
+          updaterJsonPreferNsis: true
           args: ${{ matrix.args }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- enable Tauri updater artifacts in the app bundle config
- switch the GitHub release workflow to the current tauri-action inputs
- upload updater metadata and signatures so in-app updates can detect new releases

## Why
The app checks eleases/latest/download/latest.json, but the release workflow was not publishing that manifest for Tauri v2.
