### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulsesql",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulsesql",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-table": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pulsesql",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "pulsesql"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsesql"
-version = "0.1.8"
+version = "0.1.9"
 description = "PulseSQL desktop SQL workstation"
 authors = ["Saulo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump app version metadata to 0.1.9
- prepare the first release that includes the updater-manifest fix
- allow installed 0.1.8 builds to detect a newer version
