### PR TITLE
fix: pin tauri action release version

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm ci
 
       - name: Build and upload release artifacts
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- pin the release workflow to an existing tauri-action version
- keep updater manifest/signature upload settings from the previous fix
- unblock the next tagged release build
