### PR TITLE
fix: use supported tauri updater inputs

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -73,7 +73,6 @@ jobs:
           releaseBody: "Desktop builds for macOS (Apple Silicon + Intel), Windows, and Linux."
           releaseDraft: true
           prerelease: false
-          uploadUpdaterJson: true
-          uploadUpdaterSignatures: true
+          includeUpdaterJson: true
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary
- use the updater-json input supported by the pinned tauri-action version
- remove unsupported updater upload inputs from the release workflow
- unblock the next tagged release build
