### PR TITLE
fix: regenerate Tauri updater signing key pair

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5OEU5RjVCMDFCNTZCRUMKUldUc2E3VUJXNStPK1pwakhua0I4SHpORFZ2QWUvdmJmcGJNSnVndHp6c0s4V2pLTGh6eTN1RWYK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVFMzU4Njg1MzkxRUM0MDIKUldRQ3hCNDVoWVkxWGl3UDVXR1JhQVNIbW0zbS9wUGNKN0NjUGZoNS9WbWlUcXFkYllGbWg1UWwK",
       "endpoints": [
         "https://github.com/slauers/pulsesql/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Problem
All builds since v0.1.8 failed at the signing step with:
```
failed to decode secret key: failed to decode base64 secret key: failed to decode base64 key: Invalid padding
```
This affected v0.1.9, v0.1.10, and v0.1.11 — all cancelled or failed.

## Fix
- Regenerated a new minisign key pair (no password)
- Updated `plugins.updater.pubkey` in `tauri.conf.json` with the new public key
- Updated `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` GitHub Actions secrets

## After merging
Bump version to 0.1.12, tag, and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)