### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump for the 0.1.13 release — first build with the corrected signing key pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)