### PR TITLE
ci: publish rc/beta tags as pre-release

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -84,6 +84,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Publish release
-        run: gh release edit "${{ github.ref_name }}" --draft=false
+        run: |
+          if [[ "${{ github.ref_name }}" == *"-rc"* ]] || [[ "${{ github.ref_name }}" == *"-beta"* ]]; then
+            gh release edit "${{ github.ref_name }}" --draft=false --prerelease
+          else
+            gh release edit "${{ github.ref_name }}" --draft=false
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tags com -rc ou -beta são publicadas como pre-release, sem sobrescrever latest.json para usuários em produção.