### PR TITLE
feat: inline grid editing, PK/FK badges, UX polish, update progress

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -70,9 +70,20 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "PulseSQL ${{ github.ref_name }}"
-          releaseBody: "Desktop builds for macOS (Apple Silicon + Intel), Windows, and Linux."
+          releaseBody: "Desktop builds for macOS (Apple Silicon), Windows, and Linux."
           releaseDraft: true
           prerelease: false
           includeUpdaterJson: true
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish release
+        run: gh release edit "${{ github.ref_name }}" --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
+++ b/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
@@ -89,9 +89,24 @@ public class OracleJdbcRunner {
   }
 
   private static String listColumns(Request request) throws Exception {
+    String schemaEsc = escapeSql(request.schema);
+    String tableEsc = escapeSql(request.table);
     String sql =
-        "SELECT column_name, data_type, nullable, data_default, identity_column FROM all_tab_columns WHERE owner = '" + escapeSql(request.schema) +
-        "' AND table_name = '" + escapeSql(request.table) + "' ORDER BY column_id";
+        "SELECT c.column_name, c.data_type, c.nullable, c.data_default, c.identity_column," +
+        " CASE WHEN pk.column_name IS NOT NULL THEN 'Y' ELSE 'N' END AS is_primary_key," +
+        " CASE WHEN fk.column_name IS NOT NULL THEN 'Y' ELSE 'N' END AS is_foreign_key" +
+        " FROM all_tab_columns c" +
+        " LEFT JOIN (" +
+        "   SELECT cc.column_name FROM all_cons_columns cc" +
+        "   JOIN all_constraints con ON con.constraint_name = cc.constraint_name AND con.owner = cc.owner" +
+        "   WHERE con.constraint_type = 'P' AND cc.owner = '" + schemaEsc + "' AND cc.table_name = '" + tableEsc + "'" +
+        " ) pk ON pk.column_name = c.column_name" +
+        " LEFT JOIN (" +
+        "   SELECT cc.column_name FROM all_cons_columns cc" +
+        "   JOIN all_constraints con ON con.constraint_name = cc.constraint_name AND con.owner = cc.owner" +
+        "   WHERE con.constraint_type = 'R' AND cc.owner = '" + schemaEsc + "' AND cc.table_name = '" + tableEsc + "'" +
+        " ) fk ON fk.column_name = c.column_name" +
+        " WHERE c.owner = '" + schemaEsc + "' AND c.table_name = '" + tableEsc + "' ORDER BY c.column_id";
 
     try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
          Statement statement = connection.createStatement();
@@ -115,6 +130,10 @@ public class OracleJdbcRunner {
             .append(quote(trimToNull(resultSet.getString(4))))
             .append(",\"is_auto_increment\":")
             .append(String.valueOf("YES".equalsIgnoreCase(resultSet.getString(5))))
+            .append(",\"is_primary_key\":")
+            .append(String.valueOf("Y".equalsIgnoreCase(resultSet.getString(6))))
+            .append(",\"is_foreign_key\":")
+            .append(String.valueOf("Y".equalsIgnoreCase(resultSet.getString(7))))
             .append('}');
       }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -17,6 +17,8 @@ pub struct ColumnDef {
     pub nullable: Option<bool>,
     pub default_value: Option<String>,
     pub is_auto_increment: Option<bool>,
+    pub is_primary_key: Option<bool>,
+    pub is_foreign_key: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/engines/mysql.rs
+++ b/src-tauri/src/engines/mysql.rs
@@ -76,8 +76,10 @@ pub async fn list_columns(
     table: &str,
 ) -> Result<Vec<ColumnDef>, String> {
     sqlx::query_as::<_, ColumnDef>(
-        "SELECT column_name, data_type, (is_nullable = 'YES') AS nullable, column_default AS default_value, (extra LIKE '%auto_increment%') AS is_auto_increment FROM information_schema.columns WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+        "SELECT c.column_name, c.data_type, (c.is_nullable = 'YES') AS nullable, c.column_default AS default_value, (c.extra LIKE '%auto_increment%') AS is_auto_increment, (c.column_key = 'PRI') AS is_primary_key, (fk.column_name IS NOT NULL) AS is_foreign_key FROM information_schema.columns c LEFT JOIN (SELECT DISTINCT kcu.column_name FROM information_schema.key_column_usage kcu WHERE kcu.table_schema = ? AND kcu.table_name = ? AND kcu.referenced_table_name IS NOT NULL) fk ON fk.column_name = c.column_name WHERE c.table_schema = ? AND c.table_name = ? ORDER BY c.ordinal_position",
     )
+    .bind(schema)
+    .bind(table)
     .bind(schema)
     .bind(table)
     .fetch_all(pool)

--- a/src-tauri/src/engines/postgres.rs
+++ b/src-tauri/src/engines/postgres.rs
@@ -85,7 +85,7 @@ pub async fn list_columns(
     table: &str,
 ) -> Result<Vec<ColumnDef>, String> {
     sqlx::query_as::<_, ColumnDef>(
-        "SELECT column_name, data_type, (is_nullable = 'YES') AS nullable, column_default AS default_value, (column_default ILIKE 'nextval(%') AS is_auto_increment FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 ORDER BY ordinal_position",
+        "SELECT c.column_name, c.data_type, (c.is_nullable = 'YES') AS nullable, c.column_default AS default_value, (c.column_default ILIKE 'nextval(%') AS is_auto_increment, (pk.column_name IS NOT NULL) AS is_primary_key, (fk.column_name IS NOT NULL) AS is_foreign_key FROM information_schema.columns c LEFT JOIN (SELECT kcu.column_name FROM information_schema.key_column_usage kcu JOIN information_schema.table_constraints tc ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema AND tc.table_name = kcu.table_name WHERE tc.constraint_type = 'PRIMARY KEY' AND kcu.table_schema = $1 AND kcu.table_name = $2) pk ON pk.column_name = c.column_name LEFT JOIN (SELECT kcu.column_name FROM information_schema.key_column_usage kcu JOIN information_schema.table_constraints tc ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema AND tc.table_name = kcu.table_name WHERE tc.constraint_type = 'FOREIGN KEY' AND kcu.table_schema = $1 AND kcu.table_name = $2) fk ON fk.column_name = c.column_name WHERE c.table_schema = $1 AND c.table_name = $2 ORDER BY c.ordinal_position",
     )
     .bind(schema)
     .bind(table)

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,10 +1,18 @@
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 use tauri_plugin_updater::UpdaterExt;
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Clone)]
 pub struct UpdateInfo {
     pub version: String,
     pub body: Option<String>,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateProgress {
+    pub downloaded: u64,
+    pub total: Option<u64>,
+    pub percent: Option<u8>,
 }
 
 #[tauri::command]
@@ -48,8 +56,23 @@ pub async fn install_update(app: AppHandle) -> Result<(), String> {
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "No update available".to_string())?;
 
+    let app_emit = app.clone();
+    let mut downloaded: u64 = 0;
+
     update
-        .download_and_install(|_chunk, _total| {}, || {})
+        .download_and_install(
+            move |chunk, total| {
+                downloaded += chunk as u64;
+                let percent = total.map(|t| {
+                    if t == 0 { 0u8 } else { (downloaded * 100 / t).min(100) as u8 }
+                });
+                let _ = app_emit.emit(
+                    "update-progress",
+                    UpdateProgress { downloaded, total, percent },
+                );
+            },
+            || {},
+        )
         .await
         .map_err(|e| e.to_string())?;
 

--- a/src/features/database/sql-generation.ts
+++ b/src/features/database/sql-generation.ts
@@ -105,6 +105,8 @@ function createFallbackColumn(columnName: string): MetadataColumn {
     nullable: null,
     defaultValue: null,
     isAutoIncrement: null,
+    isPrimaryKey: null,
+    isForeignKey: null,
   };
 }
 

--- a/src/features/database/types.ts
+++ b/src/features/database/types.ts
@@ -6,6 +6,8 @@ export interface ColumnDef {
   nullable?: boolean | null;
   default_value?: string | null;
   is_auto_increment?: boolean | null;
+  is_primary_key?: boolean | null;
+  is_foreign_key?: boolean | null;
 }
 
 export interface MetadataColumn {
@@ -14,6 +16,8 @@ export interface MetadataColumn {
   nullable: boolean | null;
   defaultValue: string | null;
   isAutoIncrement: boolean | null;
+  isPrimaryKey: boolean | null;
+  isForeignKey: boolean | null;
 }
 
 export interface MetadataTableEntry {
@@ -47,5 +51,7 @@ export function normalizeColumnDef(column: ColumnDef): MetadataColumn {
     nullable: typeof column.nullable === 'boolean' ? column.nullable : null,
     defaultValue: typeof column.default_value === 'string' ? column.default_value.trim() || null : null,
     isAutoIncrement: typeof column.is_auto_increment === 'boolean' ? column.is_auto_increment : null,
+    isPrimaryKey: typeof column.is_primary_key === 'boolean' ? column.is_primary_key : null,
+    isForeignKey: typeof column.is_foreign_key === 'boolean' ? column.is_foreign_key : null,
   };
 }

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -20,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronDown,
+  Check,
 } from 'lucide-react';
 import ResultGrid from './ResultGrid';
 import QueryHistoryDrawer from '../history/components/QueryHistoryDrawer';
@@ -54,6 +55,8 @@ interface QueryColumnMeta {
 interface ResultGridColumn {
   name: string;
   subtitle?: string | null;
+  isPrimaryKey?: boolean;
+  isForeignKey?: boolean;
 }
 
 interface QueryExecutionResult extends QueryResult {
@@ -130,6 +133,11 @@ export default function QueryWorkspace() {
   const [pageSizeDraft, setPageSizeDraft] = useState(String(resultPageSize));
   const [connectionMenuOpen, setConnectionMenuOpen] = useState(false);
   const [connectionMenuPosition, setConnectionMenuPosition] = useState<{ x: number; y: number } | null>(null);
+  const [exportedFormat, setExportedFormat] = useState<'csv' | 'json' | null>(null);
+  const exportFeedbackRef = useRef<number | null>(null);
+  const [editingCell, setEditingCell] = useState<string | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+  const editErrorTimeoutRef = useRef<number | null>(null);
   const executeQueryRef = useRef<() => void>(() => {});
   const editorRef = useRef<any>(null);
   const connectionMenuButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -230,8 +238,6 @@ export default function QueryWorkspace() {
     setSemanticBackgroundState('running');
     setLoading(true);
     setError(null);
-    setResults([]);
-    setActiveResultIndex(0);
 
     try {
       const nextResults: QueryExecutionResult[] = [];
@@ -255,6 +261,14 @@ export default function QueryWorkspace() {
           connectionId,
           `Query executada com sucesso (${payload.result.execution_time}ms): ${summarizeStatementForLog(statement)}`,
         );
+
+        const sourceTable = resolveSimpleSourceTable(statement, targetSchema ?? null);
+        if (sourceTable?.tableName && targetEngine) {
+          const schemaForFetch = sourceTable.schemaName ?? targetSchema ?? null;
+          if (schemaForFetch) {
+            void ensureColumnsCached(connectionId, targetEngine, schemaForFetch, sourceTable.tableName).catch(() => null);
+          }
+        }
       }
 
       setResults(nextResults);
@@ -495,6 +509,12 @@ export default function QueryWorkspace() {
     if (semanticResetTimeoutRef.current) {
       window.clearTimeout(semanticResetTimeoutRef.current);
     }
+    if (exportFeedbackRef.current) {
+      window.clearTimeout(exportFeedbackRef.current);
+    }
+    if (editErrorTimeoutRef.current) {
+      window.clearTimeout(editErrorTimeoutRef.current);
+    }
     setSemanticBackgroundState('idle');
   }, [setSemanticBackgroundState]);
 
@@ -604,6 +624,73 @@ export default function QueryWorkspace() {
       setLoading(false);
     }
   }, [activeResult, activeResultIndex, ensureExecutionConnectionReady, engine, metadataByConnection, pageSizeDraft, resolvedConnectionId, resultPageSize, schemaLabel, setResultPageSize]);
+
+  const handleCellEdit = useCallback(async (
+    colName: string,
+    rowIndex: number,
+    newValue: string | null,
+    row: Record<string, unknown>,
+  ) => {
+    if (!resolvedConnectionId || !activeSourceTable?.tableName) return;
+
+    const pkCols = cachedSourceColumns?.filter((c) => c.isPrimaryKey) ?? [];
+    if (!pkCols.length) {
+      setEditError('No primary key detected — cannot safely update this row.');
+      setEditingCell(`${rowIndex}-${colName}`);
+      if (editErrorTimeoutRef.current) window.clearTimeout(editErrorTimeoutRef.current);
+      editErrorTimeoutRef.current = window.setTimeout(() => {
+        setEditError(null);
+        setEditingCell(null);
+      }, 3500);
+      return;
+    }
+
+    const cellKey = `${rowIndex}-${colName}`;
+    setEditingCell(cellKey);
+    setEditError(null);
+
+    try {
+      await ensureExecutionConnectionReady(resolvedConnectionId);
+      const sql = buildUpdateSql(
+        activeSourceTable.schemaName,
+        activeSourceTable.tableName,
+        colName,
+        newValue,
+        row,
+        pkCols,
+        engine ?? 'postgres',
+      );
+      await invoke('execute_query', {
+        connId: resolvedConnectionId,
+        query: sql,
+        page: 1,
+        pageSize: 1,
+      });
+      setResults((current) =>
+        current.map((item, idx) =>
+          idx === activeResultIndex
+            ? {
+                ...item,
+                rows: item.rows.map((r, rIdx) =>
+                  rIdx === rowIndex ? { ...r, [colName]: newValue } : r,
+                ),
+              }
+            : item,
+        ),
+      );
+    } catch (err: any) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setEditError(msg);
+      if (editErrorTimeoutRef.current) window.clearTimeout(editErrorTimeoutRef.current);
+      editErrorTimeoutRef.current = window.setTimeout(() => {
+        setEditError(null);
+        setEditingCell(null);
+      }, 3500);
+      return;
+    }
+
+    setEditingCell(null);
+  }, [activeResultIndex, activeSourceTable, cachedSourceColumns, engine, ensureExecutionConnectionReady, resolvedConnectionId]);
 
   const handleConnectionChange = useCallback((nextConnectionId: string) => {
     if (!activeTab) {
@@ -952,17 +1039,35 @@ export default function QueryWorkspace() {
                         />
                       </label>
                       <button
-                        onClick={() => exportRowsAsCsv(activeResult.columns, filteredRows, buildExportBaseName(connectionLabel))}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs text-muted hover:bg-border/30 hover:text-text"
+                        onClick={() => {
+                          exportRowsAsCsv(activeResult.columns, filteredRows, buildExportBaseName(connectionLabel));
+                          if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
+                          setExportedFormat('csv');
+                          exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
+                        }}
+                        className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs transition-colors ${
+                          exportedFormat === 'csv'
+                            ? 'border-emerald-400/40 bg-emerald-400/12 text-emerald-200'
+                            : 'border-border text-muted hover:bg-border/30 hover:text-text'
+                        }`}
                       >
-                        <Download size={13} />
+                        {exportedFormat === 'csv' ? <Check size={13} /> : <Download size={13} />}
                         CSV
                       </button>
                       <button
-                        onClick={() => exportRowsAsJson(filteredRows, buildExportBaseName(connectionLabel))}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs text-muted hover:bg-border/30 hover:text-text"
+                        onClick={() => {
+                          exportRowsAsJson(filteredRows, buildExportBaseName(connectionLabel));
+                          if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
+                          setExportedFormat('json');
+                          exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
+                        }}
+                        className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs transition-colors ${
+                          exportedFormat === 'json'
+                            ? 'border-emerald-400/40 bg-emerald-400/12 text-emerald-200'
+                            : 'border-border text-muted hover:bg-border/30 hover:text-text'
+                        }`}
                       >
-                        <FileJson size={13} />
+                        {exportedFormat === 'json' ? <Check size={13} /> : <FileJson size={13} />}
                         JSON
                       </button>
                     </>
@@ -971,9 +1076,9 @@ export default function QueryWorkspace() {
               ) : null}
             </div>
 
-            <div className="flex-1 overflow-auto bg-background/10">
+            <div className="flex-1 overflow-auto bg-background/10 relative">
               {loading ? (
-                <div className="h-full flex items-center justify-center text-muted">
+                <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/55 backdrop-blur-[1px]">
                   <div className="flex items-center gap-3">
                     <LoaderCircle size={16} className="animate-spin text-primary" />
                     <span className="text-[10px] uppercase tracking-[0.14em] text-primary/70">
@@ -981,7 +1086,8 @@ export default function QueryWorkspace() {
                     </span>
                   </div>
                 </div>
-              ) : error ? (
+              ) : null}
+              {error && !loading ? (
                 <QueryErrorPanel error={error} activeSchema={schemaLabel} />
               ) : activeResult ? (
                 <div className="flex h-full min-h-0 flex-col">
@@ -1002,6 +1108,9 @@ export default function QueryWorkspace() {
                         rows={filteredRows}
                         rowNumberOffset={quickFilter ? 0 : rowNumberOffset}
                         density={density}
+                        onCellEdit={activeSourceTable ? handleCellEdit : undefined}
+                        editingCell={editingCell}
+                        editError={editError}
                       />
                     ) : (
                       <div className="h-full flex items-center justify-center text-muted/50 text-sm">
@@ -1444,6 +1553,8 @@ function buildGridColumns(
     return {
       name,
       subtitle,
+      isPrimaryKey: metadataMatch?.isPrimaryKey === true,
+      isForeignKey: metadataMatch?.isForeignKey === true,
     };
   });
 }
@@ -1546,4 +1657,56 @@ function summarizeStatementForLog(statement: string) {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 140);
+}
+
+function quoteIdentifier(name: string, engine: DatabaseEngine): string {
+  if (engine === 'mysql') return `\`${name.replace(/`/g, '``')}\``;
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function quoteValue(value: string | null, dataType: string, engine: DatabaseEngine): string {
+  if (value === null) return 'NULL';
+  const type = dataType.toLowerCase();
+  const isNumeric = /^(int|integer|bigint|smallint|tinyint|mediumint|numeric|decimal|float|double|real|number)/.test(type);
+  const isBool = /^(bool|boolean)/.test(type);
+  if (isNumeric && /^-?\d+(\.\d+)?$/.test(value.trim())) return value.trim();
+  if (isBool && /^(true|false)$/i.test(value.trim())) return value.trim().toLowerCase();
+  const escaped = engine === 'mysql'
+    ? value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+    : value.replace(/'/g, "''");
+  return `'${escaped}'`;
+}
+
+function buildUpdateSql(
+  schemaName: string | null,
+  tableName: string,
+  colName: string,
+  newValue: string | null,
+  row: Record<string, unknown>,
+  pkCols: import('./../../features/database/types').MetadataColumn[],
+  engine: DatabaseEngine,
+): string {
+  const qi = (n: string) => quoteIdentifier(n, engine);
+  const tableRef = schemaName ? `${qi(schemaName)}.${qi(tableName)}` : qi(tableName);
+
+  const setCols = pkCols.some((pk) => pk.columnName === colName)
+    ? [colName]
+    : [colName];
+
+  const setClause = setCols
+    .map((c) => {
+      const pkCol = pkCols.find((p) => p.columnName === c);
+      return `${qi(c)} = ${quoteValue(newValue, pkCol?.dataType ?? '', engine)}`;
+    })
+    .join(', ');
+
+  const whereClause = pkCols
+    .map((pk) => {
+      const pkVal = row[pk.columnName];
+      const rawPkStr = pkVal === null || pkVal === undefined ? null : String(pkVal);
+      return `${qi(pk.columnName)} = ${quoteValue(rawPkStr, pk.dataType, engine)}`;
+    })
+    .join(' AND ');
+
+  return `UPDATE ${tableRef} SET ${setClause} WHERE ${whereClause}`;
 }

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -1,17 +1,23 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, LoaderCircle } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 interface ResultGridProps {
   columns: Array<{
     name: string;
     subtitle?: string | null;
+    isPrimaryKey?: boolean;
+    isForeignKey?: boolean;
   }>;
   rows: any[];
   rowNumberOffset?: number;
   density?: 'compact' | 'comfortable';
+  onCellEdit?: (colName: string, rowIndex: number, newValue: string | null, row: Record<string, unknown>) => Promise<void>;
+  editingCell?: string | null;
+  editError?: string | null;
 }
 
-export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density = 'comfortable' }: ResultGridProps) {
+export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density = 'comfortable', onCellEdit, editingCell, editError }: ResultGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const [activeResize, setActiveResize] = useState<{
@@ -19,6 +25,11 @@ export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density
     startX: number;
     startWidth: number;
   } | null>(null);
+  const [copiedCell, setCopiedCell] = useState<string | null>(null);
+  const copyTimeoutRef = useRef<number | null>(null);
+  const [activeEditCell, setActiveEditCell] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState('');
+  const editInputRef = useRef<HTMLInputElement>(null);
 
   const resolvedWidths = useMemo(
     () =>
@@ -67,6 +78,54 @@ export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density
     };
   }, [activeResize]);
 
+  useEffect(() => () => {
+    if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
+  }, []);
+
+  const anyEditActive = activeEditCell !== null || editingCell !== null;
+
+  const lockedRowIndex = (() => {
+    const key = activeEditCell ?? editingCell;
+    if (!key) return null;
+    const idx = parseInt(key, 10);
+    return Number.isNaN(idx) ? null : idx;
+  })();
+
+  const handleCellClick = (cellKey: string, value: unknown, rowIndex: number) => {
+    if (anyEditActive && lockedRowIndex === rowIndex) return;
+    if (activeEditCell) return;
+    const text = value === null ? '' : formatCellValue(value);
+    navigator.clipboard.writeText(text).catch(() => null);
+    if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
+    setCopiedCell(cellKey);
+    copyTimeoutRef.current = window.setTimeout(() => setCopiedCell(null), 1200);
+  };
+
+  const openEdit = (cellKey: string, value: unknown) => {
+    if (!onCellEdit || anyEditActive) return;
+    setActiveEditCell(cellKey);
+    setEditDraft(value === null ? '' : formatCellValue(value));
+    if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
+    setCopiedCell(null);
+  };
+
+  const commitEdit = async (colName: string, rowIndex: number, row: Record<string, unknown>) => {
+    if (!onCellEdit || !activeEditCell) return;
+    setActiveEditCell(null);
+    await onCellEdit(colName, rowIndex, editDraft === '' ? null : editDraft, row);
+  };
+
+  const cancelEdit = () => {
+    setActiveEditCell(null);
+  };
+
+  useEffect(() => {
+    if (activeEditCell && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [activeEditCell]);
+
   return (
     <div ref={parentRef} className="h-full w-full overflow-auto bg-transparent relative">
       {!rows.length ? (
@@ -92,8 +151,20 @@ export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density
               style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
             >
               <div className="px-3 py-1.5 leading-tight whitespace-nowrap overflow-hidden text-ellipsis">
-                <div className="overflow-hidden text-ellipsis text-sm font-medium normal-case tracking-normal text-text">
-                  {col.name}
+                <div className="flex items-center gap-1.5 overflow-hidden">
+                  <span className="overflow-hidden text-ellipsis text-sm font-medium normal-case tracking-normal text-text">
+                    {col.name}
+                  </span>
+                  {col.isPrimaryKey ? (
+                    <span className="shrink-0 rounded px-1 py-px text-[9px] font-semibold uppercase tracking-wide bg-amber-400/18 text-amber-300 border border-amber-400/30">
+                      PK
+                    </span>
+                  ) : null}
+                  {col.isForeignKey ? (
+                    <span className="shrink-0 rounded px-1 py-px text-[9px] font-semibold uppercase tracking-wide bg-sky-400/18 text-sky-300 border border-sky-400/30">
+                      FK
+                    </span>
+                  ) : null}
                 </div>
                 {col.subtitle ? (
                   <div className="overflow-hidden text-ellipsis text-[10px] font-normal normal-case tracking-normal text-muted/60">
@@ -125,29 +196,78 @@ export default function ResultGrid({ columns, rows, rowNumberOffset = 0, density
           {rowVirtualizer.getVirtualItems().map((virtualRow) => {
             const row = rows[virtualRow.index];
             const rowTone = virtualRow.index % 2 === 0 ? 'bg-[#0A1321]' : 'bg-[#0D1726]';
+            const isThisRowLocked = lockedRowIndex === virtualRow.index;
             return (
               <div
                 key={virtualRow.key}
-                className={`group absolute w-full flex text-sm transition-colors ${rowTone} hover:bg-primary/10`}
+                className={`group absolute w-full flex text-sm transition-colors ${rowTone} ${isThisRowLocked ? 'ring-1 ring-inset ring-primary/30' : 'hover:bg-primary/10'}`}
                 style={{
                   height: `${virtualRow.size}px`,
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
-                <div className={`w-14 px-2 flex items-center justify-center border-r border-border/20 text-xs text-muted/50 font-mono sticky left-0 shrink-0 ${rowTone} group-hover:bg-primary/10`}>
+                <div className={`w-14 px-2 flex items-center justify-center border-r border-border/20 text-xs text-muted/50 font-mono sticky left-0 shrink-0 ${rowTone} ${isThisRowLocked ? '' : 'group-hover:bg-primary/10'}`}>
                   {rowNumberOffset + virtualRow.index + 1}
                 </div>
                 {columns.map((col, cIdx) => {
                   const val = row[col.name];
                   const displayValue = formatCellValue(val);
+                  const cellKey = `${virtualRow.index}-${col.name}`;
+                  const isCopied = copiedCell === cellKey;
+                  const isEditing = activeEditCell === cellKey;
+                  const isPendingEdit = editingCell === cellKey;
+                  const hasEditError = editError != null && editingCell === cellKey;
+                  const isInactiveCell = isThisRowLocked && !isEditing && !isPendingEdit && !hasEditError;
                   return (
-                    <div 
-                      key={cIdx} 
-                      className="px-3 flex items-center whitespace-nowrap overflow-hidden text-ellipsis border-r border-border/20 font-mono text-text"
+                    <div
+                      key={cIdx}
+                      onClick={() => handleCellClick(cellKey, val, virtualRow.index)}
+                      onDoubleClick={() => openEdit(cellKey, val)}
+                      className={`px-3 flex items-center gap-1.5 whitespace-nowrap overflow-hidden border-r border-border/20 font-mono transition-colors ${
+                        isEditing
+                          ? 'bg-primary/10 outline outline-1 outline-primary/60 p-0'
+                          : isPendingEdit
+                            ? 'bg-sky-400/10 text-sky-100'
+                            : hasEditError
+                              ? 'bg-red-400/12 text-red-100'
+                              : isInactiveCell
+                                ? 'opacity-35 pointer-events-none select-none text-text'
+                                : isCopied
+                                  ? 'bg-emerald-400/16 text-emerald-100'
+                                  : 'text-text cursor-pointer text-ellipsis'
+                      }`}
                       style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
-                      title={displayValue}
+                      title={hasEditError ? editError : displayValue}
                     >
-                      {val === null ? <span className="text-muted/50 italic">null</span> : displayValue}
+                      {isEditing ? (
+                        <input
+                          ref={editInputRef}
+                          value={editDraft}
+                          onChange={(e) => setEditDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              void commitEdit(col.name, virtualRow.index, row as Record<string, unknown>);
+                            } else if (e.key === 'Escape') {
+                              cancelEdit();
+                            }
+                          }}
+                          onBlur={() => void commitEdit(col.name, virtualRow.index, row as Record<string, unknown>)}
+                          className="w-full h-full px-3 bg-transparent text-text font-mono text-sm outline-none"
+                        />
+                      ) : isPendingEdit ? (
+                        <>
+                          <LoaderCircle size={11} className="shrink-0 text-sky-400 animate-spin" />
+                          <span className="overflow-hidden text-ellipsis opacity-50">{val === null ? <span className="italic">null</span> : displayValue}</span>
+                        </>
+                      ) : isCopied ? (
+                        <>
+                          <Check size={11} className="shrink-0 text-emerald-400" />
+                          <span className="overflow-hidden text-ellipsis">{val === null ? <span className="italic">null</span> : displayValue}</span>
+                        </>
+                      ) : (
+                        val === null ? <span className="text-muted/50 italic">null</span> : displayValue
+                      )}
                     </div>
                   );
                 })}

--- a/src/features/updater/UpdateNotifier.tsx
+++ b/src/features/updater/UpdateNotifier.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { ArrowUpCircle } from 'lucide-react';
 import { createPortal } from 'react-dom';
 
@@ -8,15 +9,29 @@ export interface UpdateInfo {
   body: string | null;
 }
 
-type InstallState = 'idle' | 'installing';
+interface UpdateProgress {
+  downloaded: number;
+  total: number | null;
+  percent: number | null;
+}
+
+type InstallState = 'idle' | 'downloading' | 'installing';
 
 export function UpdateButton({ update }: { update: UpdateInfo }) {
   const [open, setOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>('idle');
+  const [progress, setProgress] = useState<UpdateProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      unlistenRef.current?.();
+    };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -46,16 +61,33 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
   }, [open]);
 
   const handleInstall = async () => {
-    setInstallState('installing');
+    setInstallState('downloading');
+    setProgress(null);
     setError(null);
+
+    unlistenRef.current?.();
+    unlistenRef.current = await listen<UpdateProgress>('update-progress', (event) => {
+      setProgress(event.payload);
+      setInstallState('downloading');
+    });
+
     try {
       await invoke('install_update');
       // app.restart() is called on the Rust side — execution stops here on most platforms.
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setInstallState('idle');
+      unlistenRef.current?.();
+      unlistenRef.current = null;
     }
   };
+
+  const progressPercent = progress?.percent ?? null;
+  const progressLabel = progress
+    ? progressPercent !== null
+      ? `${progressPercent}%`
+      : `${formatBytes(progress.downloaded)} downloaded`
+    : null;
 
   return (
     <>
@@ -96,6 +128,28 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
                 ) : null}
               </div>
 
+              {installState === 'downloading' ? (
+                <div className="mx-4 mb-3">
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-[11px] text-muted">Downloading…</span>
+                    {progressLabel ? (
+                      <span className="text-[11px] text-primary/80">{progressLabel}</span>
+                    ) : null}
+                  </div>
+                  <div className="h-1 w-full overflow-hidden rounded-full bg-border/50">
+                    <div
+                      className="h-full rounded-full bg-primary transition-all duration-300"
+                      style={{ width: progressPercent !== null ? `${progressPercent}%` : '100%' }}
+                    />
+                  </div>
+                  {progressPercent === null ? (
+                    <div className="h-1 w-full overflow-hidden rounded-full bg-border/50 -mt-1">
+                      <div className="h-full w-1/3 rounded-full bg-primary/60 animate-[slide_1.4s_ease-in-out_infinite]" />
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
               {error ? (
                 <div className="mx-4 mb-3 rounded-lg border border-border/60 bg-background/24 px-3 py-2 text-[11px] text-muted">
                   {error}
@@ -106,13 +160,13 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
                 <button
                   type="button"
                   onClick={() => void handleInstall()}
-                  disabled={installState === 'installing'}
+                  disabled={installState !== 'idle'}
                   className="inline-flex items-center gap-1.5 rounded-lg bg-primary/90 px-3 py-1.5 text-[12px] font-medium text-white hover:bg-primary disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {installState === 'installing' ? (
+                  {installState !== 'idle' ? (
                     <>
                       <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                      Installing…
+                      {installState === 'downloading' ? 'Downloading…' : 'Installing…'}
                     </>
                   ) : (
                     'Install & Restart'
@@ -121,7 +175,7 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
                 <button
                   type="button"
                   onClick={() => setOpen(false)}
-                  disabled={installState === 'installing'}
+                  disabled={installState !== 'idle'}
                   className="px-3 py-1.5 text-[12px] text-muted hover:text-text disabled:opacity-40"
                 >
                   Later
@@ -133,4 +187,10 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
         : null}
     </>
   );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
Grid editing:
- Double-click any cell to edit inline; Enter to commit, Escape to cancel
- Auto-executes UPDATE…SET…WHERE using PK columns for the WHERE clause
- While a row is being edited, all other cells in that row are dimmed and pointer-events disabled — prevents opening a second edit simultaneously
- Pending cell shows a spinner while the UPDATE is in flight
- Edit disabled (with 3.5s error message) when no PK is detected

PK/FK badges in column headers:
- Amber "PK" badge and sky-blue "FK" badge in result grid column headers
- Backend now returns is_primary_key and is_foreign_key for PostgreSQL, MySQL, and Oracle (updated queries + Java sidecar)

UX polish:
- Export buttons (CSV/JSON) flash green checkmark for 1.5s after click
- Single-click a cell copies its value to clipboard with green flash
- Loading overlay appears over the previous grid instead of clearing it — no flash/jump between queries
- Column metadata (PK/FK) pre-fetched inside the query loop so badges appear as soon as metadata arrives, not one render cycle later

Auto-update improvements:
- CI: added publish-release job that runs after all platform builds succeed and publishes the draft — latest.json now goes live automatically
- install_update emits update-progress events (downloaded, total, percent)
- UpdateNotifier shows a download progress bar with percentage or byte count