### PR TITLE
feat: release notes in update toast + CHANGELOG.md (#27)

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -61,6 +61,24 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Extract changelog for this release
+        id: changelog
+        shell: bash
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          # Extract the block between the first ## [X.Y.Z] heading and the next one
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="Desktop builds for macOS (Apple Silicon), Windows, and Linux."
+          fi
+          # Store multi-line output
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and upload release artifacts
         uses: tauri-apps/tauri-action@v0.6.2
         env:
@@ -70,7 +88,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "PulseSQL ${{ github.ref_name }}"
-          releaseBody: "Desktop builds for macOS (Apple Silicon), Windows, and Linux."
+          releaseBody: ${{ steps.changelog.outputs.notes }}
           releaseDraft: true
           prerelease: false
           includeUpdaterJson: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to PulseSQL are documented here.
+
+## [0.1.15] - Unreleased
+
+## [0.1.14] - 2025-03-xx
+
+### Added
+- Grid sorting: click any column header to sort results ascending/descending
+- Delete row confirmation dialog (replaces browser confirm dialog)
+- Copy feedback on cell click with visual indicator
+- Explorer error retry button when schema/table metadata fails to load
+- Query error retry button in the query workspace
+- Empty-state CTA button when no connections are saved
+- Per-line copy button on connection logs and history entries
+- Import/Export connections: backup and restore all connections as JSON
+- Bottom-of-sidebar "New connection" button
+
+### Fixed
+- Connection removal broken due to `window.confirm()` returning `false` in Tauri's WebView
+- All connection log messages now always output in English regardless of app locale
+
+## [0.1.13] - 2025-02-xx
+
+### Added
+- Query history: view, search, and re-run past executions
+- Delete individual history entries or clear all history
+- Fullscreen result grid mode
+
+## [0.1.12] - 2025-01-xx
+
+### Added
+- Autocommit toggle per connection in status bar
+- COMMIT / ROLLBACK controls when a transaction is open
+- Server time display in status bar
+
+## [0.1.11] - 2024-12-xx
+
+### Added
+- SSH tunnel support for all database engines
+- Oracle JDBC sidecar with automatic JDK detection and download
+- Connection favorite: auto-open a designated connection on startup
+
+## [0.1.10] - 2024-11-xx
+
+### Added
+- Inline cell editing in the result grid (double-click to edit)
+- Primary key and foreign key badges on column headers
+- Quick filter bar for result grid rows
+
+## [0.1.9] - 2024-10-xx
+
+### Added
+- Result grid virtualization for large result sets
+- Pagination controls with configurable page size
+- Column resizing by dragging header separators

--- a/src/features/updater/UpdateNotifier.tsx
+++ b/src/features/updater/UpdateNotifier.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { ArrowUpCircle } from 'lucide-react';
 import { createPortal } from 'react-dom';
+import { marked } from 'marked';
 
 export interface UpdateInfo {
   version: string;
@@ -122,9 +123,10 @@ export function UpdateButton({ update }: { update: UpdateInfo }) {
                   A new version is ready to install.
                 </div>
                 {update.body ? (
-                  <div className="mt-2 text-[11px] leading-relaxed text-muted">
-                    {update.body}
-                  </div>
+                  <div
+                    className="mt-3 text-[11px] leading-relaxed text-muted/80 prose-sm max-h-48 overflow-y-auto [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:space-y-0.5 [&_h3]:font-semibold [&_h3]:text-text [&_h3]:mt-2 [&_h3]:mb-1"
+                    dangerouslySetInnerHTML={{ __html: marked.parse(update.body) as string }}
+                  />
                 ) : null}
               </div>
 


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` with version entries from v0.1.9 through v0.1.14
- CI workflow extracts the matching `## [X.Y.Z]` block from the changelog and uses it as `releaseBody` — falls back to the generic string if the version isn't listed
- `UpdateNotifier.tsx` now renders `update.body` as Markdown using `marked` (already in node_modules), with capped height and scroll for long notes

## How to maintain
Before each release, add a `## [X.Y.Z]` section to `CHANGELOG.md` with `### Added`, `### Fixed`, etc. The CI picks it up automatically from the tag name.

## Test plan
- [ ] Add a `## [0.1.15]` entry to CHANGELOG.md, tag `v0.1.15` — verify release body matches
- [ ] Simulate an update with a body string containing markdown — verify it renders with bullets/headings in the toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)