### PR TITLE
chore: bump version to 0.1.15

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bumps `version` in `tauri.conf.json` from `0.1.14` to `0.1.15`

## Test plan
- [ ] CI builds succeed after merge and tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)