### PR TITLE
feat: ATLAS layout redesign

### DIFF
--- a/.REFACTOR.md
+++ b/.REFACTOR.md
@@ -1,0 +1,337 @@
+// Direction 4 — "ATLAS" (architectural, spatial, per-connection color)
+// Each connection has an identity color (like a tab color in Chrome/Arc). That color
+// tints the editor frame, run button, active tab, and result header — so you always
+// know which DB you're hitting. Semantic feedback = color saturates + ring animates.
+
+const ATLAS_BASE = {
+  name: 'ATLAS',
+  tagline: 'Per-connection identity color. Spatial geometry. Run button lights up with it.',
+  bg: '#08111A',
+  bgElev: '#0D1824',
+  bgPanel: '#0A1420',
+  bgChip: '#12202E',
+  border: '#1A2C3C',
+  borderStrong: '#2A4559',
+  text: '#EDF4FB',
+  textDim: '#8AA3B6',
+  textMute: '#4E6375',
+  // connection-specific accents
+  accents: {
+    supabase: '#3ECF8E',   // green
+    oracle:   '#E86A4E',   // orange-red
+    analytics:'#7B6BFF',   // indigo
+    ssh:      '#FFB547',   // amber
+    local:    '#47C4E8',   // cyan
+  },
+};
+
+function AtlasDirection() {
+  const t = ATLAS_BASE;
+  const activeColor = t.accents.supabase;  // current connection color
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.text,
+      fontFamily: '"Inter", "SF Pro Text", system-ui, sans-serif',
+      fontSize: 13, display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    }}>
+      {/* Ambient color wash tied to active connection */}
+      <div style={{
+        position: 'absolute', top: 0, left: 0, right: 0, height: 160,
+        background: `radial-gradient(ellipse 60% 100% at 20% 0%, ${activeColor}18, transparent 60%)`,
+        pointerEvents: 'none',
+      }} />
+
+      {/* Title bar */}
+      <div style={{
+        height: 38, flexShrink: 0, display: 'flex', alignItems: 'center',
+        padding: '0 14px 0 76px', borderBottom: `1px solid ${t.border}`,
+        position: 'relative', zIndex: 1,
+      }}>
+        <PulseSQLMark size={14} color={activeColor} />
+        <span style={{ fontWeight: 700, marginLeft: 8, letterSpacing: 0.2 }}>PulseSQL</span>
+
+        {/* Breadcrumb with color chip */}
+        <div style={{ marginLeft: 14, display: 'flex', alignItems: 'center', gap: 0, fontSize: 12 }}>
+          <div style={{
+            padding: '4px 10px 4px 10px', borderRadius: '6px 0 0 6px',
+            background: activeColor + '18', border: `1px solid ${activeColor}50`, borderRight: 'none',
+            display: 'flex', alignItems: 'center', gap: 6,
+          }}>
+            <div style={{ width: 8, height: 8, borderRadius: 2, background: activeColor, boxShadow: `0 0 8px ${activeColor}` }} />
+            <span style={{ color: t.text, fontWeight: 600 }}>Supabase Prod</span>
+          </div>
+          <div style={{
+            padding: '4px 10px', borderRadius: '0 6px 6px 0',
+            background: t.bgChip, border: `1px solid ${t.border}`,
+            color: t.textDim, fontSize: 11.5,
+          }}>
+            public <span style={{ color: t.textMute, fontSize: 10 }}>▾</span>
+          </div>
+        </div>
+
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 10, alignItems: 'center' }}>
+          <span style={{
+            fontSize: 10, letterSpacing: 1, fontWeight: 600, color: activeColor,
+            padding: '3px 9px', borderRadius: 999, border: `1px solid ${activeColor}40`, background: `${activeColor}10`,
+          }}>
+            ● LIVE
+          </span>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', minHeight: 0, position: 'relative', zIndex: 1 }}>
+        {/* Sidebar */}
+        <aside style={{
+          width: 252, flexShrink: 0, borderRight: `1px solid ${t.border}`,
+          display: 'flex', flexDirection: 'column', background: 'rgba(10,20,32,0.5)',
+        }}>
+          <div style={{
+            padding: '14px 14px 8px', fontSize: 10, fontWeight: 700,
+            letterSpacing: 1.6, color: t.textDim, textTransform: 'uppercase',
+            display: 'flex', alignItems: 'center', gap: 8,
+          }}>
+            <span>Connections</span>
+            <div style={{ flex: 1, height: 1, background: t.border }} />
+            <span style={{ color: t.textMute, fontFamily: 'ui-monospace, monospace' }}>5</span>
+          </div>
+
+          {[
+            { ...MOCK_CONNECTIONS[0], color: t.accents.supabase },
+            { ...MOCK_CONNECTIONS[1], color: t.accents.oracle },
+            { ...MOCK_CONNECTIONS[2], color: t.accents.analytics },
+            { ...MOCK_CONNECTIONS[3], color: t.accents.ssh },
+            { ...MOCK_CONNECTIONS[4], color: t.accents.local },
+          ].map((c, i) => {
+            const active = i === 0;
+            return (
+              <div key={c.id} style={{
+                margin: '0 8px 3px', padding: '9px 10px', borderRadius: 8, cursor: 'pointer',
+                background: active ? `${c.color}12` : 'transparent',
+                border: `1px solid ${active ? c.color + '40' : 'transparent'}`,
+                display: 'flex', alignItems: 'center', gap: 10,
+              }}>
+                <div style={{ width: 3, height: 26, borderRadius: 2, background: c.color, boxShadow: active ? `0 0 10px ${c.color}` : 'none', opacity: active ? 1 : 0.55 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: active ? 600 : 500, color: active ? t.text : t.text, display: 'flex', alignItems: 'center', gap: 6 }}>
+                    {c.favorite && <span style={{ color: c.color, fontSize: 10 }}>★</span>}
+                    {c.name}
+                  </div>
+                  <div style={{ fontSize: 10.5, color: t.textMute, marginTop: 2, fontFamily: 'ui-monospace, "SF Mono", monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {c.detail}
+                  </div>
+                </div>
+                <div style={{
+                  padding: '1px 5px', borderRadius: 3, fontSize: 9, fontWeight: 700,
+                  letterSpacing: 0.5, color: c.color, border: `1px solid ${c.color}40`,
+                  background: `${c.color}10`,
+                }}>
+                  {c.engine === 'oracle' ? 'ORA' : 'PG'}
+                </div>
+              </div>
+            );
+          })}
+
+          <button style={{
+            margin: '8px 8px 12px', padding: '9px 10px', borderRadius: 8, fontSize: 12,
+            background: 'transparent', color: t.textDim, border: `1px dashed ${t.borderStrong}`,
+            cursor: 'pointer',
+          }}>
+            + New connection
+          </button>
+
+          <div style={{ borderTop: `1px solid ${t.border}`, padding: '10px 14px 6px', fontSize: 10, fontWeight: 700, letterSpacing: 1.6, color: t.textDim, textTransform: 'uppercase' }}>
+            Tables
+          </div>
+          <div style={{ padding: '0 6px', overflow: 'hidden', flex: 1 }}>
+            {MOCK_TABLES.map(tb => (
+              <div key={tb.name} style={{
+                padding: '5px 10px', fontSize: 11.5, color: tb.type === 'view' ? t.textDim : t.text,
+                display: 'flex', alignItems: 'center', gap: 8, fontFamily: 'ui-monospace, "SF Mono", monospace',
+                borderRadius: 6, cursor: 'pointer',
+              }}>
+                <span style={{ color: tb.type === 'view' ? activeColor : t.textMute, fontSize: 10 }}>{tb.type === 'view' ? '◇' : '▦'}</span>
+                <span style={{ flex: 1 }}>{tb.name}</span>
+                <span style={{ color: t.textMute, fontSize: 10 }}>{tb.rows}</span>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        {/* Main */}
+        <main style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+          {/* Tab strip */}
+          <div style={{ display: 'flex', alignItems: 'stretch', background: 'rgba(10,20,32,0.4)' }}>
+            {[
+              { name: 'users_by_mrr.sql', active: true, color: activeColor },
+              { name: 'audit_last7.sql', active: false, color: t.accents.oracle },
+              { name: 'warehouse.sql', active: false, color: t.accents.analytics },
+            ].map((tab, i) => (
+              <div key={i} style={{
+                padding: '10px 14px', fontSize: 12, fontWeight: tab.active ? 600 : 500,
+                color: tab.active ? t.text : t.textDim,
+                background: tab.active ? t.bgElev : 'transparent',
+                borderRight: `1px solid ${t.border}`, borderBottom: tab.active ? `1px solid ${t.bgElev}` : `1px solid ${t.border}`,
+                cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8,
+                position: 'relative',
+              }}>
+                {tab.active && (
+                  <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 2, background: tab.color, boxShadow: `0 0 10px ${tab.color}` }} />
+                )}
+                <div style={{ width: 6, height: 6, borderRadius: 1, background: tab.color, opacity: tab.active ? 1 : 0.55 }} />
+                {tab.name}
+                <span style={{ color: t.textMute, marginLeft: 4 }}>×</span>
+              </div>
+            ))}
+            <button style={{ padding: '10px 14px', background: 'none', border: 'none', color: t.textDim, cursor: 'pointer', borderBottom: `1px solid ${t.border}`, flex: 1, textAlign: 'left' }}>+</button>
+          </div>
+
+          {/* Toolbar */}
+          <div style={{ padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10, background: t.bgElev, borderBottom: `1px solid ${t.border}` }}>
+            <button style={{
+              padding: '7px 16px', borderRadius: 7, fontSize: 12, fontWeight: 700,
+              background: activeColor, color: '#001810', border: 'none', cursor: 'pointer',
+              boxShadow: `0 0 18px ${activeColor}60, inset 0 1px 0 rgba(255,255,255,0.2)`,
+              display: 'flex', alignItems: 'center', gap: 8, letterSpacing: 0.4,
+            }}>
+              ▶️ Run <span style={{ opacity: 0.55, fontFamily: 'ui-monospace, monospace', fontSize: 10 }}>⌘↵</span>
+            </button>
+            <button style={{ padding: '6px 12px', borderRadius: 7, fontSize: 12, background: t.bgChip, color: t.text, border: `1px solid ${t.border}`, cursor: 'pointer' }}>
+              Explain
+            </button>
+            <button style={{ padding: '6px 12px', borderRadius: 7, fontSize: 12, background: 'transparent', color: t.textDim, border: `1px solid ${t.border}`, cursor: 'pointer' }}>
+              Format
+            </button>
+            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 12, fontSize: 11, fontFamily: 'ui-monospace, monospace', color: t.textDim }}>
+              <span>23 L · 412 c</span>
+              <span>Ln 12, Col 8</span>
+            </div>
+          </div>
+
+          {/* Editor with identity border */}
+          <div style={{
+            padding: '14px 16px 14px 0', display: 'flex', fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+            fontSize: 13, lineHeight: 1.7, background: t.bgPanel,
+            borderLeft: `2px solid ${activeColor}`, borderBottom: `1px solid ${t.border}`,
+            boxShadow: `inset 4px 0 18px -4px ${activeColor}20`,
+          }}>
+            <div style={{ width: 44, textAlign: 'right', paddingRight: 14, color: t.textMute, userSelect: 'none', fontSize: 12 }}>
+              {Array.from({ length: 12 }, (_, i) => <div key={i}>{i + 1}</div>)}
+            </div>
+            <pre style={{ margin: 0, color: t.text, whiteSpace: 'pre', flex: 1 }}>
+              {renderSql(MOCK_SQL)}
+            </pre>
+          </div>
+
+          {/* Result header */}
+          <div style={{
+            padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 14,
+            background: t.bgElev, borderBottom: `1px solid ${t.border}`,
+          }}>
+            <div style={{ display: 'flex', gap: 4, padding: 2, background: t.bg, borderRadius: 7, border: `1px solid ${t.border}` }}>
+              <div style={{ padding: '4px 12px', borderRadius: 5, fontSize: 11, background: activeColor + '20', color: activeColor, fontWeight: 600, border: `1px solid ${activeColor}40` }}>
+                Result
+              </div>
+              <div style={{ padding: '4px 12px', borderRadius: 5, fontSize: 11, color: t.textDim }}>Log</div>
+              <div style={{ padding: '4px 12px', borderRadius: 5, fontSize: 11, color: t.textDim }}>Plan</div>
+            </div>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 11, fontFamily: 'ui-monospace, monospace', color: t.textDim }}>
+              <span style={{ color: activeColor }}>✓</span> 10 / 194 rows
+              <span style={{ color: t.textMute }}>│</span>
+              <span style={{ color: activeColor }}>42 ms</span>
+            </div>
+
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+              <input placeholder="filter…" style={{
+                padding: '5px 10px', borderRadius: 6, fontSize: 11,
+                background: t.bgPanel, border: `1px solid ${t.border}`,
+                color: t.text, width: 140, fontFamily: 'ui-monospace, monospace',
+              }} />
+              <button style={{ padding: '5px 10px', borderRadius: 6, fontSize: 11, background: 'transparent', color: t.textDim, border: `1px solid ${t.border}`, cursor: 'pointer' }}>
+                Export
+              </button>
+            </div>
+          </div>
+
+          {/* Grid */}
+          <div style={{ flex: 1, overflow: 'auto', background: t.bgPanel, fontFamily: 'ui-monospace, "SF Mono", monospace', fontSize: 11.5 }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ position: 'sticky', top: 0, background: t.bgElev, zIndex: 1 }}>
+                  <th style={{ width: 36, padding: '7px 10px', textAlign: 'right', color: t.textMute, fontSize: 10, borderBottom: `1px solid ${t.border}` }}>#</th>
+                  {MOCK_COLUMNS.map((c, i) => (
+                    <th key={c} style={{
+                      textAlign: 'left', padding: '7px 12px',
+                      color: t.textDim, fontWeight: 600, fontSize: 10.5,
+                      letterSpacing: 0.6, textTransform: 'uppercase',
+                      borderBottom: `1px solid ${t.border}`,
+                    }}>
+                      {i === 0 && <span style={{ color: activeColor, marginRight: 5, fontSize: 9 }}>▪</span>}
+                      {c}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {MOCK_ROWS.map((r, i) => (
+                  <tr key={i} style={{ borderBottom: `1px solid ${t.border}60` }}>
+                    <td style={{ padding: '6px 10px', color: t.textMute, fontSize: 10, textAlign: 'right' }}>{i + 1}</td>
+                    {r.map((cell, j) => {
+                      const isStatus = j === 6;
+                      const statusMap = {
+                        active: activeColor, trialing: t.accents.local, past_due: t.accents.ssh,
+                        canceled: t.accents.oracle,
+                      };
+                      const statusColor = statusMap[cell] || t.textMute;
+                      return (
+                        <td key={j} style={{
+                          padding: '6px 12px',
+                          color: j === 0 ? activeColor : t.text,
+                          fontWeight: j === 4 ? 600 : 400,
+                          whiteSpace: 'nowrap',
+                        }}>
+                          {isStatus ? (
+                            <span style={{
+                              fontSize: 10, padding: '2px 7px', borderRadius: 4,
+                              background: `${statusColor}18`, color: statusColor,
+                              letterSpacing: 0.4, fontWeight: 600, textTransform: 'uppercase',
+                            }}>{cell}</span>
+                          ) : cell}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Status bar */}
+          <div style={{
+            flexShrink: 0, display: 'flex', alignItems: 'center', gap: 14,
+            fontSize: 10.5, color: t.textMute, fontFamily: 'ui-monospace, monospace',
+            padding: '6px 14px', borderTop: `1px solid ${t.border}`, background: t.bg,
+            letterSpacing: 0.5, textTransform: 'uppercase',
+          }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+              <span style={{ width: 6, height: 6, borderRadius: 2, background: activeColor, boxShadow: `0 0 6px ${activeColor}` }} />
+              <span style={{ color: activeColor }}>Supabase Prod</span>
+            </span>
+            <span>·</span>
+            <span>pg 15.4</span>
+            <span>·</span>
+            <span>14:22:08Z</span>
+            <span>·</span>
+            <span>10 rows · 42 ms</span>
+            <span style={{ marginLeft: 'auto', color: activeColor }}>autocommit</span>
+            <span>·</span>
+            <span>v1.1.14</span>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+window.AtlasDirection = AtlasDirection;
+window.ATLAS_BASE = ATLAS_BASE;

--- a/docs/new-layout.md
+++ b/docs/new-layout.md
@@ -1,0 +1,220 @@
+# ATLAS Layout — Plano de Ação
+
+Referência visual: screenshot + `.REFACTOR.md`
+Referência de código: CLAUDE.md (arquitetura do projeto)
+
+> Marcar cada parte como `[x]` assim que estiver pronta.
+
+---
+
+## Parte 1 — Tema ATLAS (cores base) `[x]`
+
+**O que mudar:** `src/index.css` + `src/themes/index.ts`
+
+O ATLAS usa uma paleta diferente da atual. Atualizar as CSS vars e o tema `pulsesql-dark`.
+
+| Token      | Atual        | ATLAS        |
+|------------|-------------|-------------|
+| background | `#0B0F14`   | `#08111A`   |
+| surface    | `#10171F`   | `#0D1824`   |
+| border     | `#1D2A34`   | `#1A2C3C`   |
+| primary    | `#2BD3C9`   | (não usado — cada conexão tem a sua cor) |
+| text       | `#E6EDF3`   | `#EDF4FB`   |
+| muted      | `#88A0AF`   | `#8AA3B6`   |
+
+Body background: trocar o radial-gradient atual por fundo **flat** `#08111A` (o ambient wash virá via código, não CSS).
+
+**Arquivos:** `src/index.css` (vars CSS) · `src/themes/index.ts` (objeto do tema `pulsesql-dark`)
+
+---
+
+## Parte 2 — Ambient connection wash `[x]`
+
+**O que mudar:** `ConnectionManager.tsx` ou wrapper do workspace
+
+Adicionar um `<div>` absoluto no topo do conteúdo principal com:
+```
+background: radial-gradient(ellipse 60% 100% at 20% 0%, {connectionColor}18, transparent 60%)
+height: 160px
+top: 0, left: 0, right: 0
+pointer-events: none
+z-index: 0
+```
+Muda de cor conforme a conexão ativa.
+
+**Arquivos:** `src/features/connections/ConnectionManager.tsx`
+
+---
+
+## Parte 3 — Title bar `[x]`
+
+**O que mudar:** Novo componente `TitleBar.tsx` inserido no topo do layout
+
+O ATLAS tem uma barra de título de 38px (abaixo dos traffic lights do macOS — `padding-left: 76px`):
+
+- **Logo**: ícone PulseSQL colorido com `connectionColor`
+- **"PulseSQL"** em `font-weight: 700`
+- **Breadcrumb**: dois pills colados:
+  - Left pill: `[color dot 8px] [Connection Name]` — fundo `color+18`, borda `color+50`, sem borda direita
+  - Right pill: `[schema] [▾]` — fundo `bgChip`, borda `border`
+- **"● LIVE"** badge (dir): borda `color+40`, fundo `color+10`, texto `connectionColor`
+- Borda inferior: `1px solid border`
+
+**Arquivos:** `src/features/connections/TitleBar.tsx` (novo) · `src/features/connections/ConnectionManager.tsx` (inserir)
+
+---
+
+## Parte 4 — Sidebar redesign `[x]`
+
+**O que mudar:** `ConnectionManager.tsx` — seção do sidebar
+
+### 4a — Header da seção "CONNECTIONS"
+Trocar "Explorer" pelo padrão ATLAS:
+```
+CONNECTIONS  ─────────────────  5
+```
+- Label `text-[10px] font-bold tracking uppercase letter-spacing-[1.6px]`
+- Linha horizontal separadora
+- Contagem de conexões (monospace, `textMute`)
+
+### 4b — Itens de conexão
+Cada item vira um `<div>` (já é `<button>` — manter) com:
+- `margin: 0 8px 3px` · `padding: 9px 10px` · `borderRadius: 8px`
+- Active: `background: color+12`, `border: 1px solid color+40`
+- Inactive: background transparente
+- **Left bar**: `width: 3, height: 26` (tamanho fixo, não full-height), `borderRadius: 2`
+  - Active: glow `0 0 10px color`, opacidade 1
+  - Inactive: opacidade 0.55, sem glow
+- **Engine badge** (direita): pill colorido com `color` da conexão (texto + borda + fundo)
+  - Mostrar `PG` para postgres, `ORA` para oracle, `MY` para mysql
+
+### 4c — Seção Tables
+Separador com `borderTop: 1px solid border` + label "TABLES"
+Items com:
+- Ícone `▦` (table) ou `◇` (view) — colorido com `textMute` / `activeColor`
+- Nome em monospace
+- Row count alinhado à direita em `textMute`
+
+**Arquivos:** `src/features/connections/ConnectionManager.tsx`
+
+---
+
+## Parte 5 — Tab strip redesign `[x]`
+
+**O que mudar:** `QueryWorkspace.tsx` — tab bar
+
+O design atual usa `rounded-t-lg border-b-2` (borda inferior). O ATLAS usa **barra superior de 2px com glow**.
+
+### Mudanças:
+- Remover `rounded-t-lg` e `border-b-2` dos tabs
+- Tab ativo: `background: bgElev` (sólido), borda inferior = `1px solid bgElev` (funde com toolbar)
+- Tab inativo: background transparente, borda inferior = `1px solid border`
+- **Indicador superior** (active only): `<div>` absoluto `top: 0, height: 2px, background: tabColor, boxShadow: 0 0 10px tabColor`
+- Dot colorido: mantido (já existe)
+- Tab strip container: `background: rgba(10,20,32,0.4)` (flat, sem `glass-panel` ou `rounded-lg`)
+- Botão `+`: flush, sem borda, fundo none, `borderBottom: 1px solid border`, `flex: 1` para empurrar à direita
+
+**Arquivos:** `src/features/query/QueryWorkspace.tsx`
+
+---
+
+## Parte 6 — Toolbar & Run button `[x]`
+
+**O que mudar:** `QueryWorkspace.tsx` — barra de ferramentas
+
+### Run button (mudança principal)
+O ATLAS usa botão **sólido** — NÃO transparente/tintado:
+```
+background: connectionColor  (sólido, 100%)
+color: '#001810'             (texto escuro sobre fundo brilhante)
+boxShadow: 0 0 18px color+60, inset 0 1px 0 rgba(255,255,255,0.2)
+```
+
+Atualmente está: `bg-emerald-400/18 text-emerald-200` (versão antiga) → mudei para `hexToRgba(color, 0.18)` (ainda tintado). Precisa ser sólido.
+
+### Outros botões
+- **Explain**: `background: bgChip`, `color: text`, `border: 1px solid border`
+- **Format**: transparente, `color: textDim`, `border: 1px solid border`
+- Stats (dir): monospace, `textDim` — `23 L · 412 c` e `Ln 12, Col 8`
+
+### Toolbar container
+- `background: bgElev`
+- `borderBottom: 1px solid border`
+- Remover `glass-panel` do card que engloba tabs + toolbar
+
+**Arquivos:** `src/features/query/QueryWorkspace.tsx`
+
+---
+
+## Parte 7 — Result tabs (pill style) `[x]`
+
+**O que mudar:** `QueryWorkspace.tsx` — header da área de resultados
+
+O atual usa `border-b-2` (underline). O ATLAS usa **pills dentro de um container**:
+
+```
+Container: background: bg, borderRadius: 7, border: 1px solid border, padding: 2
+Active pill: background: color+20, color: activeColor, border: 1px solid color+40, borderRadius: 5
+Inactive pill: background: none, color: textDim
+```
+
+Stats de execução ao lado:
+- `✓ 10 / 194 rows` — checkmark e contagem coloridos com `connectionColor`
+- `42 ms` — colorido com `connectionColor`
+- Separador `│` em `textMute`
+
+**Arquivos:** `src/features/query/QueryWorkspace.tsx`
+
+---
+
+## Parte 8 — Status bar redesign `[x]`
+
+**O que mudar:** `ConnectionManager.tsx` — barra inferior
+
+O ATLAS tem status bar **monospace + uppercase + letter-spacing** com estrutura:
+
+```
+[● ConnName] · [pg 15.4] · [14:22:08Z] · [10 rows · 42 ms]    [AUTOCOMMIT] · [v1.1.14]
+```
+
+- Background: `bg` (mais escuro que o atual `glass-panel`)
+- Sem `glass-panel`, sem `rounded-lg`
+- Fonte: `ui-monospace, monospace`
+- Tudo uppercase, `font-size: 10.5px`, `letter-spacing: 0.5`
+- Conexão: dot glowing + nome colorido com `connectionColor` (já parcialmente feito)
+- Autocommit: alinhado à direita, colorido com `connectionColor`
+- Versão: alinhada à direita
+
+**Arquivos:** `src/features/connections/ConnectionManager.tsx`
+
+---
+
+## Ordem de execução recomendada
+
+```
+1 → 2 → 5 → 6 → 7 → 3 → 4 → 8
+```
+*(Tema e workspace primeiro para ver o resultado. Title bar e sidebar depois. Status bar por último.)*
+
+---
+
+## Estado atual (completo)
+
+| Item | Status |
+|------|--------|
+| Paleta de cores por conexão (`getConnectionColor`) | ✅ feito |
+| Run button sólido com cor da conexão | ✅ feito |
+| Editor left border + glow | ✅ feito |
+| Tab strip — dot colorido | ✅ feito |
+| Tab strip — indicador superior (top 2px + glow) | ✅ feito |
+| Connection selector — dot colorido | ✅ feito |
+| Sidebar — left bar por conexão + engine badge | ✅ feito |
+| Status bar — nome colorido + dot | ✅ feito |
+| Tema ATLAS (cores base) | ✅ feito |
+| Ambient connection wash | ✅ feito |
+| Title bar (76px left padding para traffic lights) | ✅ feito |
+| Result tabs pill style | ✅ feito |
+| Sidebar header "CONNECTIONS" ATLAS style | ✅ feito |
+| Tab strip flat + top indicator | ✅ feito |
+| Status bar monospace/uppercase | ✅ feito |
+| macOS backgroundColor atualizado (#08111A) | ✅ feito |

--- a/src-tauri/src/engines/mysql.rs
+++ b/src-tauri/src/engines/mysql.rs
@@ -466,7 +466,7 @@ async fn execute_query_on_active_connection(
 }
 
 fn is_result_set_query(query: &str) -> bool {
-    let upper = query.trim_start().to_uppercase();
+    let upper = strip_leading_sql_comments(query).to_uppercase();
     upper.starts_with("SELECT")
         || upper.starts_with("WITH")
         || upper.starts_with("SHOW")
@@ -475,8 +475,32 @@ fn is_result_set_query(query: &str) -> bool {
 }
 
 fn is_paginable_result_query(query: &str) -> bool {
-    let upper = query.trim_start().to_uppercase();
+    let upper = strip_leading_sql_comments(query).to_uppercase();
     upper.starts_with("SELECT") || upper.starts_with("WITH")
+}
+
+fn strip_leading_sql_comments(query: &str) -> &str {
+    let mut rest = query.trim_start();
+
+    loop {
+        if let Some(next) = rest.strip_prefix("--") {
+            rest = match next.find('\n') {
+                Some(index) => next[index + 1..].trim_start(),
+                None => "",
+            };
+            continue;
+        }
+
+        if let Some(next) = rest.strip_prefix("/*") {
+            rest = match next.find("*/") {
+                Some(index) => next[index + 2..].trim_start(),
+                None => "",
+            };
+            continue;
+        }
+
+        return rest;
+    }
 }
 
 fn mysql_value_to_json(row: &sqlx::mysql::MySqlRow, index: usize) -> Value {

--- a/src-tauri/src/engines/postgres.rs
+++ b/src-tauri/src/engines/postgres.rs
@@ -2,8 +2,8 @@ use crate::connection::types::ConnectionConfig;
 use crate::db::{ColumnDef, QueryColumnMeta, QueryResult};
 use serde_json::{json, Value};
 use sqlx::{
-    pool::PoolConnection, postgres::PgConnection, postgres::PgPoolOptions, raw_sql, PgPool,
-    Postgres, Row,
+    pool::PoolConnection, postgres::PgConnection, postgres::PgPoolOptions, raw_sql, Column,
+    PgPool, Postgres, Row, TypeInfo,
 };
 use std::time::{Duration, Instant};
 
@@ -414,43 +414,38 @@ fn decode_jsonb_rows(rows: Vec<sqlx::postgres::PgRow>) -> Result<Vec<Value>, Str
         .collect()
 }
 
-/// Extracts column names and type metadata by inspecting the JSON keys of the first row.
-/// The `to_jsonb` wrapper preserves the original column names as JSON keys and PG knows
-/// the types from the inner query, but we only have the JSON value here — so we infer the
-/// data_type from the JSON value type. This is sufficient for the frontend display.
+/// Extracts column names and type metadata from the actual PostgreSQL row metadata.
+/// This preserves the original SELECT order; reading keys from the JSON payload would
+/// alphabetize them because the JSON object map does not keep insertion order here.
 fn extract_columns_and_meta_from_jsonb(
     rows: &[sqlx::postgres::PgRow],
 ) -> (Vec<String>, Vec<QueryColumnMeta>) {
-    let first = rows.first().and_then(|row| row.try_get::<Value, _>("__blacktable_json").ok());
+    let Some(first) = rows.first() else {
+        return (Vec::new(), Vec::new());
+    };
 
-    match first {
-        Some(Value::Object(map)) => {
-            let columns: Vec<String> = map.keys().cloned().collect();
-            let column_meta: Vec<QueryColumnMeta> = map
-                .iter()
-                .map(|(k, v)| QueryColumnMeta {
-                    name: k.clone(),
-                    data_type: json_value_type_name(v).to_string(),
-                })
-                .collect();
-            (columns, column_meta)
-        }
-        _ => (Vec::new(), Vec::new()),
-    }
-}
+    let columns: Vec<String> = first
+        .columns()
+        .iter()
+        .filter(|column| column.name() != "__blacktable_json")
+        .map(|column| column.name().to_string())
+        .collect();
 
-fn json_value_type_name(v: &Value) -> &'static str {
-    match v {
-        Value::Number(n) if n.is_i64() || n.is_u64() => "BIGINT",
-        Value::Number(_) => "FLOAT8",
-        Value::Bool(_) => "BOOL",
-        Value::Null => "TEXT",
-        _ => "TEXT",
-    }
+    let column_meta: Vec<QueryColumnMeta> = first
+        .columns()
+        .iter()
+        .filter(|column| column.name() != "__blacktable_json")
+        .map(|column| QueryColumnMeta {
+            name: column.name().to_string(),
+            data_type: column.type_info().name().to_string(),
+        })
+        .collect();
+
+    (columns, column_meta)
 }
 
 fn is_result_set_query(query: &str) -> bool {
-    let upper = query.trim_start().to_uppercase();
+    let upper = strip_leading_sql_comments(query).to_uppercase();
     upper.starts_with("SELECT")
         || upper.starts_with("WITH")
         || upper.starts_with("SHOW")
@@ -458,6 +453,30 @@ fn is_result_set_query(query: &str) -> bool {
 }
 
 fn is_paginable_result_query(query: &str) -> bool {
-    let upper = query.trim_start().to_uppercase();
+    let upper = strip_leading_sql_comments(query).to_uppercase();
     upper.starts_with("SELECT") || upper.starts_with("WITH")
+}
+
+fn strip_leading_sql_comments(query: &str) -> &str {
+    let mut rest = query.trim_start();
+
+    loop {
+        if let Some(next) = rest.strip_prefix("--") {
+            rest = match next.find('\n') {
+                Some(index) => next[index + 1..].trim_start(),
+                None => "",
+            };
+            continue;
+        }
+
+        if let Some(next) = rest.strip_prefix("/*") {
+            rest = match next.find("*/") {
+                Some(index) => next[index + 2..].trim_start(),
+                None => "",
+            };
+            continue;
+        }
+
+        return rest;
+    }
 }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -5,7 +5,7 @@
         "label": "main",
         "titleBarStyle": "Transparent",
         "hiddenTitle": true,
-        "backgroundColor": "#0B0F14"
+        "backgroundColor": "#08111A"
       }
     ]
   }

--- a/src/features/connections/ConnectionManager.tsx
+++ b/src/features/connections/ConnectionManager.tsx
@@ -4,34 +4,26 @@ import { invoke } from '@tauri-apps/api/core';
 import {
   ChevronsLeft,
   ChevronsRight,
-  PanelLeft,
   Check,
   Copy,
   CircleAlert,
   Download,
-  Eye,
-  EyeOff,
-  Expand,
   FileText,
   Info,
   CheckCircle2,
-  LoaderCircle,
   Plus,
   Plug,
   PlugZap,
   Star,
   Upload,
   XCircle,
-  Dot,
 } from 'lucide-react';
 import { marked } from 'marked';
 import tauriConfig from '../../../src-tauri/tauri.conf.json';
 import changelog from '../../../CHANGELOG.md?raw';
 import oracleMark from '../../assets/oracle-mark.svg';
 import postgresMark from '../../assets/postgres-mark.svg';
-import pulsesqlFooter from '../../assets/pulsesql-footer.svg';
-import pulsesqlFooterCompact from '../../assets/pulsesql-footer-compact.svg';
-import { ConnectionConfig, useConnectionsStore } from '../../store/connections';
+import { ConnectionConfig, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { useConnectionRuntimeStore, type RuntimeConnectionState } from '../../store/connectionRuntime';
 import { useDatabaseSessionStore } from '../../store/databaseSession';
 import { useUiPreferencesStore } from '../../store/uiPreferences';
@@ -39,7 +31,8 @@ import { invalidateMetadataCache } from '../database/metadata-cache';
 import { DatabaseExplorer } from '../database/Explorer';
 import QueryWorkspace from '../query/QueryWorkspace';
 import ConnectionForm from './ConnectionForm';
-import { translate } from '../../i18n';
+import TitleBar from './TitleBar';
+import { formatNumber, translate } from '../../i18n';
 
 const RECONNECT_DELAYS_MS = [800, 1600, 3200];
 const CONNECTION_MENU_WIDTH = 180;
@@ -60,6 +53,13 @@ type ConnectionTransactionStatePayload = {
   supported: boolean;
 };
 
+type WorkspaceMetricsPayload = {
+  connectionId: string | null;
+  visibleRows: number | null;
+  totalRows: number | null;
+  executionTime: number | null;
+};
+
 export default function ConnectionManager() {
   const { connections, activeConnectionId, favoriteConnectionId, addConnection, removeConnection, setActiveConnection, setFavoriteConnection } =
     useConnectionsStore();
@@ -76,26 +76,21 @@ export default function ConnectionManager() {
   );
   const runtimeStatus = useConnectionRuntimeStore((state) => state.runtimeStatus);
   const connectionLogs = useConnectionRuntimeStore((state) => state.connectionLogs);
-  const logsExpandedByConnection = useConnectionRuntimeStore((state) => state.logsExpandedByConnection);
   const autocommitByConnection = useConnectionRuntimeStore((state) => state.autocommitByConnection);
   const transactionOpenByConnection = useConnectionRuntimeStore((state) => state.transactionOpenByConnection);
   const appendLog = useConnectionRuntimeStore((state) => state.appendLog);
   const setConnectionState = useConnectionRuntimeStore((state) => state.setRuntimeStatus);
-  const setLogsExpanded = useConnectionRuntimeStore((state) => state.setLogsExpanded);
   const initializeConnectionRuntime = useConnectionRuntimeStore((state) => state.initializeConnectionRuntime);
   const setAutocommitEnabled = useConnectionRuntimeStore((state) => state.setAutocommitEnabled);
   const setTransactionOpen = useConnectionRuntimeStore((state) => state.setTransactionOpen);
   const removeConnectionRuntime = useConnectionRuntimeStore((state) => state.removeConnectionRuntime);
-  const semanticBackgroundEnabled = useUiPreferencesStore((state) => state.semanticBackgroundEnabled);
   const showServerTimeInStatusBar = useUiPreferencesStore((state) => state.showServerTimeInStatusBar);
-  const setSemanticBackgroundEnabled = useUiPreferencesStore((state) => state.setSemanticBackgroundEnabled);
   const locale = useUiPreferencesStore((state) => state.locale);
   const showAutocommitInStatusBar = useUiPreferencesStore((state) => state.showAutocommitInStatusBar);
   const sidebarWidth = useUiPreferencesStore((state) => state.sidebarWidth);
   const setSidebarWidth = useUiPreferencesStore((state) => state.setSidebarWidth);
   const sidebarCollapsed = useUiPreferencesStore((state) => state.sidebarCollapsed);
   const setSidebarCollapsed = useUiPreferencesStore((state) => state.setSidebarCollapsed);
-  const logsExpandedByDefault = useUiPreferencesStore((state) => state.logsExpandedByDefault);
   const [showForm, setShowForm] = useState(false);
   const [editingConnectionId, setEditingConnectionId] = useState<string | null>(null);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
@@ -105,10 +100,15 @@ export default function ConnectionManager() {
   const [copiedLogsId, setCopiedLogsId] = useState<string | null>(null);
   const copiedLogsTimeoutRef = useRef<number | null>(null);
   const [serverTimeValue, setServerTimeValue] = useState<string | null>(null);
+  const [workspaceMetrics, setWorkspaceMetrics] = useState<WorkspaceMetricsPayload>({
+    connectionId: null,
+    visibleRows: null,
+    totalRows: null,
+    executionTime: null,
+  });
   const [compactViewport, setCompactViewport] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth < 980 || window.innerHeight < 700 : false,
   );
-  const semanticToggleRef = useRef<HTMLButtonElement | null>(null);
   const serverTimeRequestInFlightRef = useRef(false);
   const importFileRef = useRef<HTMLInputElement | null>(null);
   const [changelogOpen, setChangelogOpen] = useState(false);
@@ -124,7 +124,6 @@ export default function ConnectionManager() {
   const selectedConnection =
     connections.find((connection) => connection.id === selectedConnectionId) ?? null;
   const statusBarConnection = activeConnection ?? selectedConnection ?? null;
-  const statusBarState = statusBarConnection ? resolveRuntimeConnectionState(runtimeStatus, statusBarConnection.id) : 'disconnected';
   const t = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) =>
     translate(locale, key, params);
   const tLog = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) =>
@@ -144,7 +143,7 @@ export default function ConnectionManager() {
                 : t('noActiveConnection');
   const serverTimeIndicator =
     showServerTimeInStatusBar && activeConnectionState === 'connected' && serverTimeValue
-      ? `${t('serverTimePrefix')} ${serverTimeValue}`
+      ? serverTimeValue
       : null;
   const activeAutocommitEnabled =
     activeConnectionId ? (autocommitByConnection[activeConnectionId] ?? true) : true;
@@ -163,6 +162,19 @@ export default function ConnectionManager() {
     ? resolveRuntimeConnectionState(runtimeStatus, contextMenuConnection.id)
     : 'disconnected';
   const effectiveSidebarWidth = sidebarCollapsed ? 68 : compactViewport ? Math.min(sidebarWidth, 300) : sidebarWidth;
+  const statusBarColor = getConnectionColor(connections, statusBarConnection?.id);
+  const statusBarEngine =
+    statusBarConnection?.engine === 'oracle'
+      ? 'ORA'
+      : statusBarConnection?.engine === 'mysql'
+        ? 'MY'
+        : statusBarConnection
+          ? 'PG'
+          : null;
+  const statusBarMetrics =
+    statusBarConnection && workspaceMetrics.connectionId === statusBarConnection.id
+      ? buildStatusBarMetrics(locale, workspaceMetrics)
+      : null;
 
   useEffect(() => {
     if (activeConnectionId && !activeConnection) {
@@ -194,6 +206,45 @@ export default function ConnectionManager() {
       window.removeEventListener('resize', updateViewportMode);
     };
   }, []);
+
+  useEffect(() => {
+    const handleWorkspaceMetrics = (event: Event) => {
+      const payload = (event as CustomEvent<WorkspaceMetricsPayload>).detail;
+      setWorkspaceMetrics(
+        payload ?? {
+          connectionId: null,
+          visibleRows: null,
+          totalRows: null,
+          executionTime: null,
+        },
+      );
+    };
+
+    window.addEventListener('pulsesql:workspace-metrics', handleWorkspaceMetrics as EventListener);
+
+    return () => {
+      window.removeEventListener('pulsesql:workspace-metrics', handleWorkspaceMetrics as EventListener);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleOpenConnectionLogs = (event: Event) => {
+      const payload = (event as CustomEvent<{ connectionId?: string | null }>).detail;
+      const targetConnectionId = payload?.connectionId ?? activeConnectionId ?? null;
+
+      if (!targetConnectionId) {
+        return;
+      }
+
+      setExpandedLogsConnectionId(targetConnectionId);
+    };
+
+    window.addEventListener('pulsesql:open-connection-logs', handleOpenConnectionLogs as EventListener);
+
+    return () => {
+      window.removeEventListener('pulsesql:open-connection-logs', handleOpenConnectionLogs as EventListener);
+    };
+  }, [activeConnectionId]);
 
   useEffect(() => {
     if (!showServerTimeInStatusBar || !activeConnection || activeConnectionState !== 'connected') {
@@ -409,10 +460,6 @@ export default function ConnectionManager() {
     }
   };
 
-  const toggleSelectedConnection = (connId: string) => {
-    setSelectedConnectionId((current) => (current === connId ? null : connId));
-  };
-
   const openConnectionContextMenu = (event: ReactMouseEvent<HTMLElement>, connId: string) => {
     event.preventDefault();
     event.stopPropagation();
@@ -461,19 +508,6 @@ export default function ConnectionManager() {
     }
   };
 
-  const handleSemanticBackgroundToggle = () => {
-    setSemanticBackgroundEnabled(!semanticBackgroundEnabled);
-
-    semanticToggleRef.current?.animate(
-      [
-        { color: 'rgba(148, 163, 184, 0.9)', textShadow: '0 0 0 rgba(110,72,255,0)' },
-        { color: 'rgba(110, 72, 255, 1)', textShadow: '0 0 14px rgba(110,72,255,0.45), 0 0 28px rgba(110,72,255,0.24)' },
-        { color: semanticBackgroundEnabled ? 'rgba(148, 163, 184, 0.9)' : 'rgba(110, 72, 255, 1)', textShadow: '0 0 0 rgba(110,72,255,0)' },
-      ],
-      { duration: 680, easing: 'ease-out' },
-    );
-  };
-
   useEffect(() => {
     if (!sidebarResizing || sidebarCollapsed) {
       return;
@@ -498,13 +532,31 @@ export default function ConnectionManager() {
   }, [sidebarCollapsed, sidebarResizing, sidebarWidth]);
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <div className="flex min-h-0 flex-1 w-full">
+    <div className="relative flex h-full w-full flex-col overflow-hidden">
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 160,
+          background: `radial-gradient(ellipse 60% 100% at 20% 0%, ${getConnectionColor(connections, activeConnectionId)}18, transparent 60%)`,
+          pointerEvents: 'none',
+          zIndex: 0,
+        }}
+      />
+      <TitleBar
+        connectionColor={getConnectionColor(connections, activeConnectionId)}
+        connectionName={activeConnection?.name ?? null}
+        schema={activeSchema}
+        isConnected={activeConnectionState === 'connected'}
+      />
+      <div className="relative z-10 flex min-h-0 flex-1 w-full">
         <div
           className="shrink-0 border-r border-border/80 bg-surface/92 flex flex-col overflow-hidden"
           style={{ width: `${effectiveSidebarWidth}px` }}
         >
-          <div className="px-3 py-2 border-b border-border/80 flex justify-between items-center sticky top-0 bg-surface/95 z-10">
+          <div className="border-b border-border/60 sticky top-0 bg-surface/95 z-10" style={{ padding: sidebarCollapsed ? '10px 8px' : '11px 14px 9px' }}>
             {sidebarCollapsed ? (
               <div className="flex w-full flex-col items-center gap-3">
                 <button
@@ -528,39 +580,42 @@ export default function ConnectionManager() {
                 </button>
               </div>
             ) : (
-              <>
-                <h2 className="text-[11px] font-medium uppercase tracking-[0.08em] text-text flex items-center gap-2">
-                  <PanelLeft size={14} /> Explorer
-                </h2>
-                <div className="flex items-center gap-1">
+              <div className="flex w-full items-center gap-2">
+                <span
+                  className="text-muted uppercase"
+                  style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.6, whiteSpace: 'nowrap' }}
+                >
+                  Connections
+                </span>
+                <div className="flex-1 h-px bg-border/60" />
+                <span className="text-muted font-mono" style={{ fontSize: 10 }}>{connections.length}</span>
+                <div className="flex items-center gap-0.5 ml-1">
                   <button
                     type="button"
                     onClick={() => importFileRef.current?.click()}
-                    className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-sky-300 hover:bg-sky-400/12 hover:text-sky-200 transition-colors"
+                    className="p-1 text-muted hover:text-sky-300 transition-colors"
                     title={t('importConnections')}
                   >
                     <Download size={12} />
-                    <span>Import</span>
                   </button>
                   <button
                     type="button"
                     onClick={openExportModal}
-                    className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-emerald-300 hover:bg-emerald-400/12 hover:text-emerald-200 transition-colors"
+                    className="p-1 text-muted hover:text-emerald-300 transition-colors"
                     title={t('exportConnections')}
                   >
                     <Upload size={12} />
-                    <span>Export</span>
                   </button>
                   <button
                     type="button"
                     onClick={toggleSidebarCollapsed}
-                    className="p-1.5 text-muted hover:bg-background/45 hover:text-text"
+                    className="p-1 text-muted hover:text-text transition-colors"
                     title={t('hideSidebar')}
                   >
-                    <ChevronsLeft size={16} />
+                    <ChevronsLeft size={14} />
                   </button>
                 </div>
-              </>
+              </div>
             )}
           </div>
 
@@ -604,161 +659,144 @@ export default function ConnectionManager() {
               })}
             </div>
           ) : (
-            <div className="flex-1 overflow-y-auto p-2 space-y-2 min-h-0">
-              <div className="space-y-1">
-                {connections.length === 0 ? (
-                  <div className="flex flex-col items-center gap-4 rounded-lg border border-border/50 bg-background/24 px-4 py-8 text-center">
-                    <div className="rounded-full border border-border/60 bg-surface/60 p-3 text-muted">
-                      <Plug size={22} />
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium text-text">{t('noSavedConnections')}</p>
-                      <p className="mt-1 text-xs text-muted/70">{t('addFirstConnection')}</p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => setShowForm(true)}
-                      className="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/12 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/18 transition-colors"
-                    >
-                      <Plus size={15} />
-                      {t('newConnection')}
-                    </button>
+            <div className="flex min-h-0 flex-1 flex-col" style={{ padding: '8px 8px 10px' }}>
+              {connections.length === 0 ? (
+                <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-border/50 bg-background/22 px-4 py-8 text-center">
+                  <div className="rounded-full border border-border/60 bg-surface/60 p-3 text-muted">
+                    <Plug size={22} />
                   </div>
-                ) : (
-                  connections.map((conn) => {
-                    const isSelected = selectedConnectionId === conn.id;
-                    const isFavorite = favoriteConnectionId === conn.id;
-                    const connectionState = resolveConnectionState(conn.id);
-                    const logsExpanded = logsExpandedByConnection[conn.id] ?? logsExpandedByDefault;
+                  <div>
+                    <p className="text-sm font-medium text-text">{t('noSavedConnections')}</p>
+                    <p className="mt-1 text-xs text-muted/70">{t('addFirstConnection')}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setShowForm(true)}
+                    className="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/12 px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary/18"
+                  >
+                    <Plus size={15} />
+                    {t('newConnection')}
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <div className="shrink-0 space-y-1.5">
+                    {connections.map((conn) => {
+                      const connectionState = resolveConnectionState(conn.id);
+                      const isActiveCard = activeConnectionId === conn.id;
+                      const isSelectedCard = selectedConnectionId === conn.id;
+                      const isHighlighted = isActiveCard || isSelectedCard;
+                      const isFavorite = favoriteConnectionId === conn.id;
+                      const connColor = getConnectionColor(connections, conn.id);
 
-                    return (
-                      <div key={conn.id} className="space-y-2">
+                      return (
                         <button
+                          key={conn.id}
                           type="button"
-                          onClick={() => toggleSelectedConnection(conn.id)}
+                          onClick={() => {
+                            setSelectedConnectionId(conn.id);
+                            if (connectionState === 'connected') {
+                              setActiveConnection(conn.id);
+                            }
+                          }}
+                          onDoubleClick={() => void openConnection(conn)}
                           onContextMenu={(event) => openConnectionContextMenu(event, conn.id)}
-                          className={`group w-full border rounded-lg px-3 py-2 text-left transition-colors ${
-                            isSelected
-                              ? 'border-primary/35 bg-background/48'
-                              : 'border-transparent bg-transparent hover:bg-background/34'
-                          }`}
+                          className="group relative w-full rounded-lg text-left transition-colors"
+                          style={{
+                            padding: '10px 10px 10px 14px',
+                            background: isHighlighted ? hexToRgba(connColor, isActiveCard ? 0.12 : 0.08) : 'transparent',
+                            border: `1px solid ${isHighlighted ? hexToRgba(connColor, isActiveCard ? 0.38 : 0.18) : 'transparent'}`,
+                          }}
                         >
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0 flex items-start gap-2">
-                              <span
-                                className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${connectionStateDot(connectionState)}`}
-                                title={translate(locale, connectionStatusLabelKey(connectionState))}
-                              />
-                              <div className="min-w-0">
-                                <div className="flex items-center gap-2 min-w-0">
-                                {collapsedConnectionMark(conn.engine) ? (
-                                  <img
-                                    src={collapsedConnectionMark(conn.engine) as string}
-                                    alt={conn.engine}
-                                    className="h-4 w-4 shrink-0 object-contain"
-                                  />
-                                ) : null}
-                                <div className="truncate text-sm font-medium text-text">{conn.name}</div>
-                                {isFavorite ? <Star size={13} className="shrink-0 fill-amber-300 text-amber-300" /> : null}
+                          <span
+                            style={{
+                              position: 'absolute',
+                              left: 0,
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                              width: 3,
+                              height: 26,
+                              borderRadius: 2,
+                              background: connColor,
+                              opacity: isHighlighted ? 1 : 0.55,
+                              boxShadow: isActiveCard ? `0 0 10px ${connColor}` : 'none',
+                            }}
+                          />
+                          <div className="flex items-start gap-3 min-w-0">
+                            <span
+                              className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${connectionStateDot(connectionState)}`}
+                              style={connectionState === 'connected' ? { background: connColor, boxShadow: `0 0 8px ${hexToRgba(connColor, 0.6)}` } : undefined}
+                              title={translate(locale, connectionStatusLabelKey(connectionState))}
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-1.5 min-w-0">
+                                <span className="truncate font-semibold text-text" style={{ fontSize: 12.5 }}>{conn.name}</span>
+                                {isFavorite ? <Star size={11} className="shrink-0 fill-amber-300 text-amber-300" /> : null}
                               </div>
-                              <div className="mt-1 truncate text-[11px] text-muted">
-                                {conn.engine.toUpperCase()} • {conn.user}@{conn.host}
-                                {conn.database ? `/${conn.database}` : ''}
+                              <div
+                                className="truncate font-mono"
+                                style={{
+                                  marginTop: 3,
+                                  fontSize: 10.5,
+                                  color: isActiveCard ? connColor : 'var(--bt-muted)',
+                                  opacity: isActiveCard ? 1 : 0.92,
+                                }}
+                              >
+                                {conn.host}{conn.database ? `/${conn.database}` : ''}
                               </div>
                             </div>
-                            </div>
+                            <span
+                              style={{
+                                padding: '2px 6px',
+                                borderRadius: 5,
+                                fontSize: 9,
+                                fontWeight: 700,
+                                letterSpacing: 0.5,
+                                color: connColor,
+                                border: `1px solid ${hexToRgba(connColor, 0.3)}`,
+                                background: hexToRgba(connColor, 0.1),
+                                flexShrink: 0,
+                              }}
+                            >
+                              {conn.engine === 'oracle' ? 'ORA' : conn.engine === 'mysql' ? 'MY' : 'PG'}
+                            </span>
                           </div>
                         </button>
+                      );
+                    })}
+                  </div>
 
-                        {isSelected ? (
-                          <div className="space-y-3 border rounded-lg border-border/70 bg-background/18 p-3">
-                            <ActionSection
-                              title={t('mainActions')}
-                              actions={buildPrimaryActions({
-                                connectionState,
-                                locale,
-                                onOpen: () => void openConnection(conn),
-                              })}
-                            />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingConnectionId(null);
+                      setShowForm(true);
+                    }}
+                    className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border/60 px-4 py-3 text-sm text-muted transition-colors hover:border-primary/45 hover:bg-primary/6 hover:text-text"
+                    title={t('newConnection')}
+                  >
+                    <Plus size={14} />
+                    {t('newConnection')}
+                  </button>
 
-                            <LogsSection
-                              locale={locale}
-                              connectionName={conn.name}
-                              expanded={logsExpanded}
-                              entries={connectionLogs[conn.id] ?? []}
-                              onToggle={() => setLogsExpanded(conn.id, !logsExpanded)}
-                              onCopy={() => void copyLogs(conn.id)}
-                              onExpand={() => setExpandedLogsConnectionId(conn.id)}
-                              copied={copiedLogsId === conn.id}
-                            />
-
-                            {activeConnectionId === conn.id ? (
-                              <DatabaseExplorer
-                                connId={conn.id}
-                                dbName={conn.database}
-                                engine={conn.engine}
-                                showRefreshButton
-                              />
-                            ) : (
-                              <div className="border border-border/60 bg-background/24 px-3 py-3 text-xs text-muted">
-                                Abra a conexao para carregar o explorer.
-                              </div>
-                            )}
-                          </div>
-                        ) : null}
+                  <div className="mt-3 min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-background/18">
+                    {activeConnection ? (
+                      <DatabaseExplorer
+                        connId={activeConnection.id}
+                        dbName={activeConnection.database}
+                        engine={activeConnection.engine}
+                        showRefreshButton
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center px-5 text-center text-xs text-muted/80">
+                        Abra uma conexao para carregar as tabelas do schema ativo.
                       </div>
-                    );
-                  })
-                )}
-              </div>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
           )}
-
-          <div
-            className={`shrink-0 border-border/70 bg-background/26 ${
-              sidebarCollapsed ? 'px-1.5 py-2' : 'px-3 py-3'
-            }`}
-          >
-            {connections.length > 0 && (!sidebarCollapsed ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingConnectionId(null);
-                  setShowForm(true);
-                }}
-                className="w-full flex items-center justify-center gap-2 mb-2.5 py-2 rounded-lg border border-dashed border-border/60 text-xs font-medium text-muted hover:text-text hover:border-primary/50 hover:bg-primary/6 transition-colors"
-                title={t('newConnection')}
-              >
-                <Plus size={13} />
-                {t('newConnection')}
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingConnectionId(null);
-                  setShowForm(true);
-                }}
-                className="w-full flex items-center justify-center mb-2 py-1.5 rounded-lg border border-dashed border-border/60 text-muted hover:text-text hover:border-primary/50 hover:bg-primary/6 transition-colors"
-                title={t('newConnection')}
-              >
-                <Plus size={14} />
-              </button>
-            ))}
-            <div
-              className={`rounded-xl border-border/60 bg-background/36 ${
-                sidebarCollapsed
-                  ? 'flex items-center justify-center px-1 py-2'
-                  : 'px-3 py-2'
-              }`}
-            >
-              <img
-                src={sidebarCollapsed ? pulsesqlFooterCompact : pulsesqlFooter}
-                alt="PulseSQL"
-                className={sidebarCollapsed ? 'h-10 w-auto opacity-95' : 'h-10 w-full object-contain opacity-95'}
-              />
-            </div>
-          </div>
         </div>
 
         {!sidebarCollapsed ? (
@@ -836,6 +874,18 @@ export default function ConnectionManager() {
           >
             <FileText size={14} className="text-muted" />
             <span>{t('editConnection')}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const connId = connectionContextMenu.connId;
+              setConnectionContextMenu(null);
+              setExpandedLogsConnectionId(connId);
+            }}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-text transition-colors hover:bg-background/55"
+          >
+            <Copy size={14} className="text-muted" />
+            <span>{t('technicalHistory')}</span>
           </button>
           <button
             type="button"
@@ -1009,64 +1059,96 @@ export default function ConnectionManager() {
         document.body
       ) : null}
 
-      <div className="shrink-0 rounded-lg border border-border/80 glass-panel px-4 py-1 text-[10px] shadow-[0_18px_42px_rgba(0,0,0,0.2)]">
-        <div className="relative flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-3 truncate text-text/90">
-            <span className="truncate">{statusBarText}</span>
-            <span className="hidden sm:inline text-muted/70">•</span>
-            <span className="hidden sm:inline text-muted/80">
-              {t('semanticBackgroundStatus')}{' '}
+      <div
+        className="relative z-10 shrink-0 flex items-center border-t border-border/50"
+        style={{
+          background: 'var(--bt-background)',
+          padding: '5px 14px',
+          fontSize: 10.5,
+          fontFamily: 'ui-monospace, "SF Mono", monospace',
+          letterSpacing: 0.5,
+          color: 'var(--bt-muted)',
+          gap: 0,
+        }}
+      >
+        <div className="flex min-w-0 flex-1 items-center truncate" style={{ gap: 0 }}>
+          {statusBarConnection ? (
+            <>
+              <span className="flex shrink-0 items-center gap-1.5">
+                <span
+                  style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: 999,
+                    display: 'inline-block',
+                    background: statusBarColor,
+                    boxShadow: `0 0 8px ${statusBarColor}`,
+                  }}
+                />
+                <span style={{ color: statusBarColor, textTransform: 'uppercase' }}>
+                  {statusBarConnection.name}
+                </span>
+              </span>
+              {statusBarEngine ? <StatusDivider /> : null}
+            </>
+          ) : null}
+
+          {statusBarEngine ? <span className="shrink-0">{statusBarEngine}</span> : null}
+
+          {serverTimeIndicator ? (
+            <>
+              <StatusDivider hiddenOnMobile />
+              <span className="hidden md:inline shrink-0">{serverTimeIndicator}</span>
+            </>
+          ) : null}
+
+          {statusBarMetrics ? (
+            <>
+              <StatusDivider hiddenOnMobile />
+              <span className="hidden md:inline truncate" style={{ color: statusBarColor }}>
+                {statusBarMetrics}
+              </span>
+            </>
+          ) : statusBarText ? (
+            <>
+              <StatusDivider hiddenOnMobile={Boolean(statusBarConnection)} />
+              <span className="truncate" style={{ textTransform: 'none' }}>{statusBarText}</span>
+            </>
+          ) : null}
+
+          {showAutocommitIndicator && activeTransactionOpen ? (
+            <>
+              <StatusDivider hiddenOnMobile />
+              <span className="hidden md:inline" style={{ color: '#7DD3FC' }}>
+                {t('transactionOpen')}
+              </span>
+            </>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 items-center" style={{ gap: 0 }}>
+          {showAutocommitIndicator ? (
+            <>
+              <StatusDivider />
               <button
-                ref={semanticToggleRef}
                 type="button"
-                onClick={handleSemanticBackgroundToggle}
-                className={`inline text-[10px] uppercase tracking-[0.14em] transition-colors ${
-                  semanticBackgroundEnabled ? 'text-primary' : 'text-slate-200/90'
-                }`}
+                onClick={() => void handleAutocommitStatusBarToggle()}
+                className="transition-colors hover:text-text"
+                style={{ color: activeAutocommitEnabled ? statusBarColor : '#F59E0B' }}
+                title={activeAutocommitEnabled ? t('autocommitOn') : t('autocommitOff')}
               >
-                {semanticBackgroundEnabled ? 'ON' : 'OFF'}
+                {activeAutocommitEnabled ? t('autocommitOn') : t('autocommitOff')}
               </button>
-            </span>
-            {serverTimeIndicator ? (
-              <>
-                <span className="hidden md:inline text-muted/70">•</span>
-                <span className="hidden md:inline text-slate-200/90">{serverTimeIndicator}</span>
-              </>
-            ) : null}
-            {showAutocommitIndicator ? (
-              <>
-                <span className="hidden md:inline text-muted/70">•</span>
-                <button
-                  type="button"
-                  onClick={() => void handleAutocommitStatusBarToggle()}
-                  className={`hidden md:inline text-[10px] uppercase tracking-[0.14em] transition-colors ${
-                    activeAutocommitEnabled ? 'text-emerald-300' : 'text-amber-300'
-                  }`}
-                  title={activeAutocommitEnabled ? t('autocommitOn') : t('autocommitOff')}
-                >
-                  {activeAutocommitEnabled ? t('autocommitOn') : t('autocommitOff')}
-                </button>
-                {activeTransactionOpen ? (
-                  <span className="hidden md:inline text-sky-300/90">{t('transactionOpen')}</span>
-                ) : null}
-              </>
-            ) : null}
-          </div>
+            </>
+          ) : null}
+          <StatusDivider />
           <button
             type="button"
             onClick={() => setChangelogOpen(true)}
-            className="absolute left-1/2 -translate-x-1/2 text-primary/80 hover:text-primary font-mono tracking-wide transition-colors"
+            className="transition-colors hover:text-text"
           >
             v{tauriConfig.version}
           </button>
-          {statusBarConnection ? (
-            <div className="flex items-center gap-2 shrink-0">
-              <span className="max-w-[220px] truncate text-[10px] uppercase tracking-[0.14em] text-slate-200/90">
-                {statusBarConnection.name}
-              </span>
-              <ConnectionBadge locale={locale} state={statusBarState} compact glowing />
-            </div>
-          ) : null}
         </div>
       </div>
 
@@ -1101,164 +1183,44 @@ export default function ConnectionManager() {
   );
 }
 
-type ActionItem = {
-  id: string;
-  label: string;
-  icon: typeof Plug;
-  onClick: () => void;
-  disabled?: boolean;
-  loading?: boolean;
-  tone?: 'default' | 'primary' | 'danger';
-};
-
-function ActionSection({ title, actions }: { title: string; actions: ActionItem[] }) {
-  if (!actions.length) {
-    return null;
-  }
-
-  return (
-    <div className="rounded-lg border border-border/60 bg-background/24 p-3">
-      <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted">{title}</div>
-      <div className="flex flex-wrap gap-2">
-        {actions.map((action) => {
-          const Icon = action.icon;
-          const tone =
-            action.tone === 'primary'
-              ? 'border-primary/40 bg-primary/12 text-primary hover:bg-primary/20'
-              : action.tone === 'danger'
-                ? 'border-red-400/25 bg-red-400/8 text-red-300 hover:bg-red-400/14'
-                : 'border-border/70 bg-background/30 text-text hover:bg-border/30';
-
-          return (
-            <button
-              key={action.id}
-              type="button"
-              onClick={action.onClick}
-              disabled={action.disabled}
-              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-colors disabled:opacity-50 ${tone}`}
-            >
-              {action.loading ? <LoaderCircle size={13} className="animate-spin" /> : <Icon size={13} />}
-              {action.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function buildPrimaryActions({
-  connectionState,
-  locale,
-  onOpen,
-}: {
-  connectionState: RuntimeConnectionState;
-  locale: 'pt-BR' | 'en-US';
-  onOpen: () => void;
-}): ActionItem[] {
-  const isBusy = connectionState === 'connecting' || connectionState === 'reconnecting';
-  const actions: ActionItem[] = [];
-
-  if (connectionState !== 'connected') {
-    actions.push({
-      id: 'open',
-      label: connectionState === 'reconnecting'
-        ? translate(locale, 'reconnectingAction')
-        : translate(locale, 'openConnectionAction'),
-      icon: Plug,
-      onClick: onOpen,
-      disabled: isBusy,
-      loading: isBusy,
-      tone: 'primary',
-    });
-  }
-
-  return actions;
-}
-
-function LogsSection({
-  locale,
-  connectionName,
-  expanded,
-  entries,
-  onToggle,
-  onCopy,
-  onExpand,
-  copied = false,
-}: {
-  locale: 'pt-BR' | 'en-US';
-  connectionName: string;
-  expanded: boolean;
-  entries: string[];
-  onToggle: () => void;
-  onCopy: () => void;
-  onExpand: () => void;
-  copied?: boolean;
-}) {
-  return (
-    <div className="rounded-lg border border-border/60 bg-background/24 p-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
-          <FileText size={12} />
-          {translate(locale, 'technicalHistory')}
-        </div>
-        <button
-          type="button"
-          onClick={onToggle}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border/70 bg-background/30 px-3 py-1.5 text-xs text-text hover:bg-border/30"
-        >
-          {expanded ? <EyeOff size={12} /> : <Eye size={12} />}
-          {expanded ? translate(locale, 'hide') : translate(locale, 'show')}
-        </button>
-      </div>
-
-      {expanded ? (
-        <div className="mt-3">
-          <div className="mb-2 flex items-center justify-end gap-1.5 text-xs text-muted">
-            <button
-              onClick={onExpand}
-              className="inline-flex items-center rounded-lg border border-border px-2 py-1 text-[11px] text-muted hover:text-text hover:bg-border/30"
-              title={`${translate(locale, 'logs')} ${connectionName}`}
-            >
-              <Expand size={11} />
-            </button>
-            <button
-              onClick={onCopy}
-              className={`inline-flex items-center rounded-lg border px-2 py-1 text-[11px] transition-colors hover:bg-border/30 ${copied ? 'border-emerald-400/40 text-emerald-300' : 'border-border text-muted hover:text-text'}`}
-              title={translate(locale, 'copyLogs')}
-            >
-              {copied ? <Check size={11} /> : <Copy size={11} />}
-            </button>
-          </div>
-          {entries.length ? (
-            <div className="max-h-40 overflow-auto space-y-1 font-mono text-[11px]">
-              {entries.map((entry, index) => {
-                const previousTimestamp = index > 0 ? extractLogParts(entries[index - 1]).timestamp : null;
-                return (
-                <ConnectionLogEntry
-                  locale={locale}
-                  key={`log-${index}`}
-                  entry={entry}
-                  highlighted={index === 0}
-                  compactTimestamp={Boolean(previousTimestamp && previousTimestamp === extractLogParts(entry).timestamp)}
-                />
-                );
-              })}
-            </div>
-          ) : (
-            <div className="text-[11px] text-muted/70">{translate(locale, 'noLogsYet')}</div>
-          )}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 function resolveRuntimeConnectionState(
   runtimeStatus: Record<string, RuntimeConnectionState>,
   connId: string,
 ): RuntimeConnectionState {
   return runtimeStatus[connId] ?? 'disconnected';
+}
+
+function StatusDivider({ hiddenOnMobile = false }: { hiddenOnMobile?: boolean }) {
+  return (
+    <span
+      className={hiddenOnMobile ? 'mx-2 hidden md:inline' : 'mx-2'}
+      style={{ opacity: 0.35 }}
+    >
+      ·
+    </span>
+  );
+}
+
+function buildStatusBarMetrics(
+  locale: 'pt-BR' | 'en-US',
+  metrics: WorkspaceMetricsPayload,
+) {
+  const parts: string[] = [];
+
+  if (typeof metrics.visibleRows === 'number') {
+    const rowLabel = translate(locale, 'rowsLabel').toUpperCase();
+    const totalPart =
+      typeof metrics.totalRows === 'number' && metrics.totalRows !== metrics.visibleRows
+        ? ` / ${formatNumber(locale, metrics.totalRows)}`
+        : '';
+    parts.push(`${formatNumber(locale, metrics.visibleRows)}${totalPart} ${rowLabel}`);
+  }
+
+  if (typeof metrics.executionTime === 'number') {
+    parts.push(`${metrics.executionTime} MS`);
+  }
+
+  return parts.join(' · ') || null;
 }
 
 function connectionShortLabel(name: string): string {
@@ -1315,51 +1277,6 @@ function connectionStatusLabelKey(state: RuntimeConnectionState) {
   return labels[state];
 }
 
-function ConnectionBadge({
-  locale,
-  state,
-  compact = false,
-  glowing = false,
-}: {
-  locale: 'pt-BR' | 'en-US';
-  state: RuntimeConnectionState;
-  compact?: boolean;
-  glowing?: boolean;
-}) {
-  const palette: Record<RuntimeConnectionState, string> = {
-    disconnected: 'border-red-400/20 bg-red-400/8 text-red-300',
-    connecting: 'border-sky-400/30 bg-sky-400/10 text-sky-300',
-    connected: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
-    reconnecting: 'border-amber-400/30 bg-amber-400/10 text-amber-300',
-    failed: 'border-red-400/30 bg-red-400/10 text-red-300',
-  };
-
-  const labels: Record<RuntimeConnectionState, string> = {
-    disconnected: translate(locale, 'statusDisconnected'),
-    connecting: translate(locale, 'statusConnecting'),
-    connected: translate(locale, 'statusConnected'),
-    reconnecting: translate(locale, 'statusReconnecting'),
-    failed: translate(locale, 'statusFailed'),
-  };
-
-  const compactGlowingConnected =
-    state === 'connected' && compact && glowing
-      ? 'border-emerald-400/20 bg-emerald-400/8 text-emerald-300 shadow-[0_0_18px_rgba(16,185,129,0.12)]'
-      : null;
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border ${
-        compact ? 'px-2 py-0.5 text-[9px]' : 'px-2.5 py-1 text-[10px]'
-      } font-medium uppercase tracking-[0.14em] ${
-        compactGlowingConnected ?? palette[state]
-      } ${glowing && !compactGlowingConnected ? 'shadow-[0_0_16px_rgba(255,255,255,0.08)]' : ''}`}
-    >
-      <Dot size={12} className="-ml-0.5 mr-0.5" />
-      <span>{labels[state]}</span>
-    </span>
-  );
-}
 
 function LogsModal({
   locale,

--- a/src/features/connections/TitleBar.tsx
+++ b/src/features/connections/TitleBar.tsx
@@ -1,0 +1,110 @@
+import { hexToRgba } from '../../store/connections';
+
+interface TitleBarProps {
+  connectionColor: string;
+  connectionName: string | null;
+  schema: string | null;
+  isConnected: boolean;
+}
+
+function PulseSQLMark({ size, color }: { size: number; color: string }) {
+  const h = size * (80 / 120);
+  return (
+    <svg width={size} height={h} viewBox="0 0 120 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 40 L30 40 L40 20 L55 60 L70 30 L85 40 L110 40"
+        stroke={color}
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function TitleBar({ connectionColor, connectionName, schema, isConnected }: TitleBarProps) {
+  return (
+    <div
+      className="relative z-10 flex shrink-0 items-center border-b border-border"
+      style={{ height: 38, padding: '0 14px 0 76px', gap: 0 }}
+      data-tauri-drag-region
+    >
+      <PulseSQLMark size={18} color={connectionColor} />
+      <span
+        className="font-bold text-text"
+        style={{ marginLeft: 8, fontSize: 13, letterSpacing: 0.2 }}
+      >
+        PulseSQL
+      </span>
+
+      {connectionName ? (
+        <div style={{ marginLeft: 14, display: 'flex', alignItems: 'center', gap: 0, fontSize: 12 }}>
+          {/* Connection name pill */}
+          <div
+            style={{
+              padding: '4px 10px',
+              borderRadius: '6px 0 0 6px',
+              background: hexToRgba(connectionColor, 0.10),
+              border: `1px solid ${hexToRgba(connectionColor, 0.32)}`,
+              borderRight: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: 2,
+                flexShrink: 0,
+                background: connectionColor,
+                boxShadow: `0 0 8px ${connectionColor}`,
+              }}
+            />
+            <span style={{ color: 'var(--bt-text)', fontWeight: 600, whiteSpace: 'nowrap' }}>
+              {connectionName}
+            </span>
+          </div>
+          {/* Schema pill */}
+          <div
+            style={{
+              padding: '4px 10px',
+              borderRadius: '0 6px 6px 0',
+              background: 'var(--bt-surface)',
+              border: '1px solid var(--bt-border)',
+              color: 'var(--bt-muted)',
+              fontSize: 11.5,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {schema ?? 'public'}{' '}
+            <span style={{ color: 'var(--bt-muted)', fontSize: 10, opacity: 0.7 }}>▾</span>
+          </div>
+        </div>
+      ) : null}
+
+      {isConnected ? (
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+          <span
+            style={{
+              fontSize: 10,
+              letterSpacing: 1,
+              fontWeight: 600,
+              color: connectionColor,
+              padding: '3px 9px',
+              borderRadius: 999,
+              border: `1px solid ${hexToRgba(connectionColor, 0.25)}`,
+              background: hexToRgba(connectionColor, 0.08),
+              whiteSpace: 'nowrap',
+            }}
+          >
+            ● LIVE
+          </span>
+        </div>
+      ) : (
+        <div style={{ marginLeft: 'auto' }} />
+      )}
+    </div>
+  );
+}

--- a/src/features/database/Explorer.tsx
+++ b/src/features/database/Explorer.tsx
@@ -11,7 +11,6 @@ import {
   FilePenLine,
   FileSearch,
   Pin,
-  LayoutTemplate,
   LoaderCircle,
   RefreshCw,
   Rows4,
@@ -81,7 +80,7 @@ const SCHEMA_MENU_WIDTH = 220;
 
 export function DatabaseExplorer({
   connId,
-  dbName,
+  dbName: _dbName,
   engine,
   showRefreshButton = true,
   refreshToken = 0,
@@ -97,6 +96,7 @@ export function DatabaseExplorer({
   const requestTabExecution = useQueriesStore((state) => state.requestTabExecution);
 
   const [loading, setLoading] = useState(true);
+  const [tablesLoading, setTablesLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [contextMenu, setContextMenu] = useState<TableContextMenuState | null>(null);
   const [schemaContextMenu, setSchemaContextMenu] = useState<SchemaContextMenuState | null>(null);
@@ -106,7 +106,10 @@ export function DatabaseExplorer({
     let cancelled = false;
 
     setLoading(true);
-    ensureSchemasCached(connId, engine, refreshToken > 0 ? { force: true } : undefined)
+    ensureSchemasCached(connId, engine, {
+      force: refreshToken > 0,
+      markActive: true,
+    })
       .catch(() => null)
       .finally(() => {
         if (!cancelled) {
@@ -144,12 +147,37 @@ export function DatabaseExplorer({
   const schemas = metadataConnection?.schemas ?? [];
   const schemaError = metadataConnection?.schemasError;
   const preferredSchema = connection?.preferredSchema ?? null;
+  const resolvedSchema = activeSchema ?? preferredSchema ?? schemas[0] ?? null;
+  const schemaEntry = resolvedSchema ? metadataConnection?.schemasByName[resolvedSchema] : undefined;
+  const tables = schemaEntry?.tables ?? [];
+  const tablesError = schemaEntry?.tablesError ?? null;
+
+  useEffect(() => {
+    if (!resolvedSchema) {
+      return;
+    }
+
+    let cancelled = false;
+    setTablesLoading(true);
+
+    ensureTablesCached(connId, engine, resolvedSchema)
+      .catch(() => null)
+      .finally(() => {
+        if (!cancelled) {
+          setTablesLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connId, engine, resolvedSchema]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
     invalidateMetadataCache(connId);
     try {
-      await ensureSchemasCached(connId, engine, { force: true });
+      await ensureSchemasCached(connId, engine, { force: true, markActive: true });
     } finally {
       setRefreshing(false);
     }
@@ -203,56 +231,72 @@ export function DatabaseExplorer({
   };
 
   return (
-    <div className="flex flex-col h-full bg-surface relative">
-      <div className="p-3 border-b border-border bg-background/50 flex items-center gap-2">
-        <Database size={16} className="text-primary" />
-        <span className="font-semibold text-sm truncate">{dbName}</span>
-        {activeSchema ? (
-          <span className="ml-auto rounded-full border border-border/70 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-muted">
-            {activeSchema}
-          </span>
+    <div className="relative flex h-full flex-col bg-surface/35">
+      <div className="flex items-center gap-2 border-b border-border/60" style={{ padding: '10px 14px 9px' }}>
+        <span className="text-muted uppercase" style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.6, whiteSpace: 'nowrap' }}>
+          Tables
+        </span>
+        <div className="flex-1 h-px bg-border/60" />
+        {resolvedSchema ? (
+          <button
+            type="button"
+            onClick={(event) =>
+              setSchemaContextMenu({
+                ...resolveMenuAnchor(event, SCHEMA_MENU_WIDTH),
+                schema: resolvedSchema,
+              })
+            }
+            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/30 px-2 py-1 text-muted transition-colors hover:bg-background/45 hover:text-text"
+            style={{ fontSize: 9.5 }}
+            title={resolvedSchema}
+          >
+            <span className="max-w-[110px] truncate">{resolvedSchema}</span>
+            <ChevronDown size={11} />
+          </button>
         ) : null}
         {showRefreshButton ? (
           <button
             type="button"
             onClick={() => void handleRefresh()}
-            className="rounded-lg border border-border/70 p-1.5 text-muted hover:bg-border/30 hover:text-text"
+            className="text-muted hover:text-text transition-colors"
             title="Atualizar metadata"
           >
-            <RefreshCw size={13} className={refreshing ? 'animate-spin' : ''} />
+            <RefreshCw size={12} className={refreshing ? 'animate-spin' : ''} />
           </button>
         ) : null}
       </div>
 
-      <div className="flex-1 overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
         {loading ? (
           <div className="flex justify-center p-4">
             <LoaderCircle size={18} className="animate-spin text-muted" />
           </div>
         ) : schemaError ? (
           <ExplorerError message={schemaError} onRetry={() => void handleRefresh()} />
-        ) : schemas.length ? (
-          <div className="mt-2">
-            {schemas.map((schema) => (
-              <SchemaItem
-                key={schema}
+        ) : !resolvedSchema ? (
+          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted/75">
+            Nenhum schema encontrado para esta conexao.
+          </div>
+        ) : tablesLoading && !tables.length ? (
+          <div className="flex justify-center p-4">
+            <LoaderCircle size={18} className="animate-spin text-muted" />
+          </div>
+        ) : tablesError ? (
+          <ExplorerError message={tablesError} onRetry={() => void handleRefresh()} />
+        ) : tables.length ? (
+          <div className="space-y-1">
+            {tables.map((table) => (
+              <FlatTableItem
+                key={table}
                 connId={connId}
                 engine={engine}
-                schema={schema}
-                active={activeSchema === schema}
-                preferred={preferredSchema === schema}
-                onActivate={() => setActiveSchema(connId, schema)}
-                onOpenSchemaContextMenu={(event) =>
-                  setSchemaContextMenu({
-                    ...resolveMenuAnchor(event, SCHEMA_MENU_WIDTH),
-                    schema,
-                  })
-                }
-                onOpenAction={(action, table) => void openQueryFromExplorer(action, schema, table)}
-                onOpenContextMenu={(event, table) =>
+                schema={resolvedSchema}
+                table={table}
+                onOpenAction={(action) => void openQueryFromExplorer(action, resolvedSchema, table)}
+                onOpenContextMenu={(event) =>
                   setContextMenu({
                     ...resolveMenuAnchor(event, TABLE_MENU_WIDTH),
-                    schema,
+                    schema: resolvedSchema,
                     table,
                   })
                 }
@@ -260,7 +304,9 @@ export function DatabaseExplorer({
             ))}
           </div>
         ) : (
-          <div className="p-3 text-sm text-muted">Nenhum schema encontrado.</div>
+          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted/75">
+            Nenhuma tabela encontrada neste schema.
+          </div>
         )}
       </div>
 
@@ -302,17 +348,28 @@ export function DatabaseExplorer({
               onMouseDown={(event) => event.stopPropagation()}
               onClick={(event) => event.stopPropagation()}
             >
-              <button
-                type="button"
-                onClick={() => {
-                  setActiveSchema(connId, schemaContextMenu.schema);
-                  setSchemaContextMenu(null);
-                }}
-                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-text transition-colors hover:bg-background/55"
-              >
-                <Crosshair size={14} className="text-muted" />
-                <span>Usar neste editor</span>
-              </button>
+              {schemas.map((schema) => (
+                <button
+                  key={schema}
+                  type="button"
+                  onClick={() => {
+                    setActiveSchema(connId, schema);
+                    setSchemaContextMenu(null);
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${
+                    schema === resolvedSchema ? 'bg-background/55 text-primary' : 'text-text hover:bg-background/55'
+                  }`}
+                >
+                  <Crosshair size={14} className="text-muted" />
+                  <span className="flex-1 truncate text-left">{schema}</span>
+                  {preferredSchema === schema ? (
+                    <span className="rounded border border-border/60 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em] text-muted">
+                      default
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+              <div className="my-1 border-t border-border/70" />
               <button
                 type="button"
                 onClick={() => openCreateTableTemplate(schemaContextMenu.schema)}
@@ -356,134 +413,15 @@ export function DatabaseExplorer({
   );
 }
 
-function SchemaItem({
-  connId,
-  engine,
-  schema,
-  active,
-  preferred,
-  onActivate,
-  onOpenSchemaContextMenu,
-  onOpenAction,
-  onOpenContextMenu,
-}: {
-  connId: string;
-  engine: DatabaseEngine;
-  schema: string;
-  active: boolean;
-  preferred: boolean;
-  onActivate: () => void;
-  onOpenSchemaContextMenu: (event: ReactMouseEvent<HTMLElement>) => void;
-  onOpenAction: (action: ExplorerActionId, table: string) => void;
-  onOpenContextMenu: (event: ReactMouseEvent<HTMLElement>, table: string) => void;
-}) {
-  const schemaEntry = useDatabaseSessionStore((state) => state.metadataByConnection[connId]?.schemasByName[schema]);
-  const [expanded, setExpanded] = useState(schema === 'public' || active);
-  const [loading, setLoading] = useState(false);
+function buildTableMetaLabel(columnCount?: number) {
+  if (typeof columnCount === 'number' && columnCount > 0) {
+    return `${columnCount}c`;
+  }
 
-  useEffect(() => {
-    if (active) {
-      setExpanded(true);
-    }
-  }, [active]);
-
-  useEffect(() => {
-    if (!expanded) {
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-    ensureTablesCached(connId, engine, schema)
-      .catch(() => null)
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [connId, engine, expanded, schema]);
-
-  const handleRetryTables = () => {
-    let cancelled = false;
-    setLoading(true);
-    ensureTablesCached(connId, engine, schema, { force: true })
-      .catch(() => null)
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => { cancelled = true; };
-  };
-
-  return (
-    <div>
-      <div
-        onContextMenu={(event) => {
-          event.preventDefault();
-          onOpenSchemaContextMenu(event);
-        }}
-        onClick={() => {
-          onActivate();
-          setExpanded((current) => !current);
-        }}
-        className={`flex items-center gap-1.5 py-1.5 px-2 rounded cursor-pointer select-none ${
-          active ? 'bg-primary/10 text-primary' : 'text-text hover:bg-border/30'
-        }`}
-      >
-        {expanded ? <ChevronDown size={15} className="text-muted" /> : <ChevronRight size={15} className="text-muted" />}
-        <LayoutTemplate size={15} className="text-amber-400" />
-        <span className="text-sm font-medium">{schema}</span>
-        {preferred ? (
-          <span className="ml-auto rounded-full border border-border/70 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-muted">
-            padrao
-          </span>
-        ) : null}
-      </div>
-
-      {expanded ? (
-        loading && !schemaEntry?.tables.length ? (
-          <div className="ml-6 py-1">
-            <LoaderCircle size={14} className="animate-spin text-muted" />
-          </div>
-        ) : schemaEntry?.tablesError ? (
-          <div className="ml-5 border-l border-border/50 pl-3 py-2">
-            <div className="text-xs text-red-300">{schemaEntry.tablesError}</div>
-            <button
-              type="button"
-              onClick={handleRetryTables}
-              className="mt-1.5 text-[11px] text-muted hover:text-text underline underline-offset-2"
-            >
-              Tentar novamente
-            </button>
-          </div>
-        ) : schemaEntry && !schemaEntry.tables.length ? (
-          <div className="ml-5 border-l border-border/50 pl-3 py-2 text-xs text-muted/60 italic">
-            Schema vazio
-          </div>
-        ) : (
-          <div className="ml-5 border-l border-border/50 pl-2">
-            {schemaEntry?.tables.map((table) => (
-              <TableItem
-                key={table}
-                connId={connId}
-                engine={engine}
-                schema={schema}
-                table={table}
-                onOpenAction={onOpenAction}
-                onOpenContextMenu={onOpenContextMenu}
-              />
-            ))}
-          </div>
-        )
-      ) : null}
-    </div>
-  );
+  return '--';
 }
 
-function TableItem({
+function FlatTableItem({
   connId,
   engine,
   schema,
@@ -495,87 +433,105 @@ function TableItem({
   engine: DatabaseEngine;
   schema: string;
   table: string;
-  onOpenAction: (action: ExplorerActionId, table: string) => void;
-  onOpenContextMenu: (event: ReactMouseEvent<HTMLElement>, table: string) => void;
+  onOpenAction: (action: ExplorerActionId) => void;
+  onOpenContextMenu: (event: ReactMouseEvent<HTMLElement>) => void;
 }) {
   const tableEntry = useDatabaseSessionStore(
     (state) => state.metadataByConnection[connId]?.schemasByName[schema]?.tablesByName[table],
   );
   const [expanded, setExpanded] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loadingColumns, setLoadingColumns] = useState(false);
 
   useEffect(() => {
     if (!expanded) {
       return;
     }
 
+    if (tableEntry?.columns?.length) {
+      return;
+    }
+
     let cancelled = false;
-    setLoading(true);
+    setLoadingColumns(true);
+
     ensureColumnsCached(connId, engine, schema, table)
       .catch(() => null)
       .finally(() => {
         if (!cancelled) {
-          setLoading(false);
+          setLoadingColumns(false);
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [connId, engine, expanded, schema, table]);
+  }, [connId, engine, expanded, schema, table, tableEntry?.columns?.length]);
+
+  const columns = tableEntry?.columns ?? [];
+  const metaLabel = buildTableMetaLabel(columns.length);
 
   return (
-    <div>
+    <div className="rounded-lg">
       <div
-        className="group flex items-center gap-1.5 py-1 text-text hover:bg-border/30 rounded select-none"
+        className="group flex items-center gap-2 rounded-lg px-2 py-2 transition-colors hover:bg-background/38"
         onContextMenu={(event) => {
           event.preventDefault();
-          onOpenContextMenu(event, table);
+          onOpenContextMenu(event);
         }}
       >
         <button
           type="button"
           onClick={() => setExpanded((current) => !current)}
-          onDoubleClick={() => void onOpenAction('selectTop100', table)}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          onDoubleClick={() => onOpenAction('selectTop100')}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          title={`${schema}.${table}`}
         >
           {expanded ? (
-            <ChevronDown size={14} className="shrink-0 text-muted" />
+            <ChevronDown size={12} className="shrink-0 text-muted" />
           ) : (
-            <ChevronRight size={14} className="shrink-0 text-muted" />
+            <ChevronRight size={12} className="shrink-0 text-muted" />
           )}
-          <Table2 size={14} className="h-[14px] w-[14px] shrink-0 text-blue-400" />
-          <span className="text-sm truncate">{table}</span>
+          <Table2 size={13} className="shrink-0 text-muted" />
+          <span className="truncate font-mono text-[13px] text-text">{table}</span>
         </button>
-
+        <span className="shrink-0 text-[11px] font-mono text-muted/70">{metaLabel}</span>
         <button
           type="button"
-          onClick={(event) => onOpenContextMenu(event, table)}
-          className="mr-1 rounded p-1 text-muted opacity-0 transition-opacity hover:bg-background/60 hover:text-text group-hover:opacity-100"
+          onClick={onOpenContextMenu}
+          className="rounded p-1 text-muted opacity-0 transition-opacity hover:bg-background/60 hover:text-text group-hover:opacity-100"
           title="Acoes da tabela"
         >
-          <EllipsisVertical size={13} />
+          <EllipsisVertical size={12} />
         </button>
       </div>
 
       {expanded ? (
-        loading && !tableEntry?.columns?.length ? (
-          <div className="ml-6 py-1">
-            <LoaderCircle size={14} className="animate-spin text-muted" />
-          </div>
-        ) : tableEntry?.columnsError ? (
-          <div className="ml-6 py-2 text-xs text-red-300">{tableEntry.columnsError}</div>
-        ) : (
-          <div className="ml-6 border-l border-border/50 pl-2">
-            {tableEntry?.columns?.map((column) => (
-              <div key={column.columnName} className="flex items-center gap-2 py-1 text-muted hover:text-text cursor-default">
-                <Columns size={13} className="opacity-70" />
-                <span className="text-sm truncate">{column.columnName}</span>
-                <span className="text-xs text-muted/60 ml-auto">{column.dataType}</span>
-              </div>
-            ))}
-          </div>
-        )
+        <div className="ml-5 border-l border-border/40 pl-3">
+          {loadingColumns && !columns.length ? (
+            <div className="flex items-center gap-2 py-2 text-[11px] text-muted">
+              <LoaderCircle size={12} className="animate-spin" />
+              Carregando colunas...
+            </div>
+          ) : tableEntry?.columnsError ? (
+            <div className="py-2 text-[11px] text-red-300">{tableEntry.columnsError}</div>
+          ) : columns.length ? (
+            <div className="py-1">
+              {columns.map((column) => (
+                <div
+                  key={column.columnName}
+                  className="flex items-center gap-2 py-1.5 text-[12px] text-muted/90"
+                  title={`${column.columnName} • ${column.dataType}`}
+                >
+                  <Columns size={12} className="shrink-0 text-muted/70" />
+                  <span className="min-w-0 flex-1 truncate font-mono text-text/90">{column.columnName}</span>
+                  <span className="shrink-0 text-[10px] font-mono text-muted/65">{column.dataType}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="py-2 text-[11px] text-muted/70">Nenhuma coluna encontrada.</div>
+          )}
+        </div>
       ) : null}
     </div>
   );

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { useQueriesStore } from '../../store/queries';
-import { type DatabaseEngine, useConnectionsStore } from '../../store/connections';
+import { type DatabaseEngine, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { invoke } from '@tauri-apps/api/core';
 import { createPortal } from 'react-dom';
 import { ensureColumnsCached, ensureSchemasCached, ensureTablesCached, invalidateMetadataCache } from '../database/metadata-cache';
@@ -97,6 +97,7 @@ export default function QueryWorkspace() {
   const { activeConnectionId, connections, setActiveConnection } = useConnectionsStore();
   const runtimeStatusMap = useConnectionRuntimeStore((state) => state.runtimeStatus);
   const transactionOpenByConnection = useConnectionRuntimeStore((state) => state.transactionOpenByConnection);
+  const connectionLogs = useConnectionRuntimeStore((state) => state.connectionLogs);
   const setRuntimeStatus = useConnectionRuntimeStore((state) => state.setRuntimeStatus);
   const appendLog = useConnectionRuntimeStore((state) => state.appendLog);
   const setAutocommitEnabled = useConnectionRuntimeStore((state) => state.setAutocommitEnabled);
@@ -119,12 +120,14 @@ export default function QueryWorkspace() {
   const activeTab = tabs.find(t => t.id === activeTabId);
   const resolvedConnectionId = activeTab?.connectionId ?? activeConnectionId ?? null;
   const selectedConnection = connections.find((connection) => connection.id === resolvedConnectionId) ?? null;
+  const connectionColor = getConnectionColor(connections, resolvedConnectionId);
   const engine = selectedConnection?.engine;
   const connectionLabel = selectedConnection?.name;
   const schemaLabel = resolvedConnectionId ? activeSchemaByConnection[resolvedConnectionId] ?? selectedConnection?.preferredSchema : undefined;
   const runtimeStatus = resolvedConnectionId ? runtimeStatusMap[resolvedConnectionId] : undefined;
   const isConnectionReady = runtimeStatus === 'connected';
   const transactionOpen = resolvedConnectionId ? transactionOpenByConnection[resolvedConnectionId] === true : false;
+  const activeConnectionLogCount = resolvedConnectionId ? (connectionLogs[resolvedConnectionId]?.length ?? 0) : 0;
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<QueryErrorPresentation | null>(null);
@@ -150,6 +153,7 @@ export default function QueryWorkspace() {
   const [selectedSourceRowIndex, setSelectedSourceRowIndex] = useState<number | null>(null);
   const [historyRefreshToken, setHistoryRefreshToken] = useState(0);
   const [gridFullscreen, setGridFullscreen] = useState(false);
+  const [activePanel, setActivePanel] = useState<'results' | 'logs'>('results');
   const editErrorTimeoutRef = useRef<number | null>(null);
   const executeQueryRef = useRef<() => void>(() => {});
   const editorRef = useRef<any>(null);
@@ -274,6 +278,7 @@ export default function QueryWorkspace() {
     setSemanticBackgroundState('running');
     setLoading(true);
     setError(null);
+    setActivePanel('results');
 
     try {
       const nextResults: QueryExecutionResult[] = [];
@@ -614,6 +619,32 @@ export default function QueryWorkspace() {
   }, [activeResultIndex, resolvedConnectionId, quickFilter, activeResult?.statement]);
 
   useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent('pulsesql:workspace-metrics', {
+        detail: {
+          connectionId: resolvedConnectionId,
+          visibleRows: activeResult ? filteredRows.length : null,
+          totalRows: activeResult?.total_rows ?? activeResult?.rows.length ?? null,
+          executionTime: activeResult?.execution_time ?? null,
+        },
+      }),
+    );
+
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent('pulsesql:workspace-metrics', {
+          detail: {
+            connectionId: resolvedConnectionId,
+            visibleRows: null,
+            totalRows: null,
+            executionTime: null,
+          },
+        }),
+      );
+    };
+  }, [activeResult, filteredRows.length, resolvedConnectionId]);
+
+  useEffect(() => {
     if (!resolvedConnectionId || !engine || !activeSourceTable?.schemaName || !activeSourceTable.tableName || runtimeStatus !== 'connected') {
       return;
     }
@@ -903,50 +934,72 @@ export default function QueryWorkspace() {
       }`}
       style={fullscreen ? undefined : { height: `${resultsHeight}%` }}
     >
-      <div className="p-2 border-b border-border text-sm font-medium text-muted flex justify-between items-center bg-background/42">
-        <div className="flex gap-2 px-2 shrink-0 overflow-x-auto scrollbar-hide">
+      <div
+        className="flex flex-wrap items-center gap-2 border-b border-border/80 px-3"
+        style={{ background: 'var(--bt-surface)', paddingTop: 8, paddingBottom: 8 }}
+      >
+        {/* Pill tabs */}
+        <div style={{ display: 'flex', gap: 2, padding: 2, background: 'var(--bt-background)', borderRadius: 7, border: '1px solid var(--bt-border)', flexShrink: 0 }}>
           {(results.length ? results : [{ title: t('result') } as QueryExecutionResult]).map((item, index) => (
-            <div
-              key={`${item.title}-${index}`}
-              className={`rounded-t-lg border-b-2 px-2.5 pb-1 pt-0.5 text-xs transition-colors ${
-                activeResultIndex === index
-                  ? 'text-text border-primary'
-                  : 'text-muted border-transparent hover:text-text hover:border-border/70'
-              }`}
-            >
+            <div key={`${item.title}-${index}`} className="inline-flex items-center">
               <button
-                onClick={() => setActiveResultIndex(index)}
-                className="inline-flex items-center gap-1.5"
+                onClick={() => { setActiveResultIndex(index); setActivePanel('results'); }}
+                className="inline-flex items-center gap-1 rounded-md px-3 py-1 text-xs font-semibold transition-colors"
+                style={activePanel === 'results' && activeResultIndex === index
+                  ? { background: hexToRgba(connectionColor, 0.15), color: connectionColor, border: `1px solid ${hexToRgba(connectionColor, 0.30)}` }
+                  : { background: 'transparent', color: 'var(--bt-muted)', border: '1px solid transparent' }
+                }
               >
-                <span>{results.length <= 1 ? t('result') : item.title}</span>
+                {results.length <= 1 ? t('result') : item.title}
+                {results.length > 1 ? (
+                  <span
+                    onClick={(event) => { event.stopPropagation(); closeResultTab(index); }}
+                    className="ml-1 hover:text-text transition-colors"
+                    aria-label={`Fechar ${item.title}`}
+                  >
+                    <X size={11} />
+                  </span>
+                ) : null}
               </button>
-              {results.length > 1 ? (
-                <button
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    closeResultTab(index);
-                  }}
-                  className="ml-1 inline-flex items-center text-muted transition-colors hover:text-text"
-                  aria-label={`Fechar ${item.title}`}
-                >
-                  <X size={12} />
-                </button>
-              ) : null}
             </div>
           ))}
+          <button
+            onClick={() => setActivePanel('logs')}
+            className="inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-semibold transition-colors"
+            style={activePanel === 'logs'
+              ? { background: hexToRgba(connectionColor, 0.15), color: connectionColor, border: `1px solid ${hexToRgba(connectionColor, 0.30)}` }
+              : { background: 'transparent', color: 'var(--bt-muted)', border: '1px solid transparent' }
+            }
+          >
+            Logs
+            {activeConnectionLogCount > 0 ? (
+              <span style={{ fontFamily: 'ui-monospace, monospace', fontSize: 10, opacity: 0.75 }}>
+                {activeConnectionLogCount}
+              </span>
+            ) : null}
+          </button>
         </div>
+
         {activeResult ? (
-          <div className="flex items-center gap-2 px-2 min-w-0">
-            <div className="hidden md:flex items-center gap-2 text-xs text-muted shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="hidden md:flex items-center gap-1.5 text-xs shrink-0" style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--bt-muted)' }}>
               {hasGridResult ? (
-                <span>
-                  {formatNumber(locale, filteredRows.length)}
-                  {quickFilter ? ` / ${formatNumber(locale, activeResult.rows.length)}` : ''} {t('rowsLabel')}
-                </span>
+                <>
+                  <span style={{ color: connectionColor }}>✓</span>
+                  <span>
+                    {formatNumber(locale, filteredRows.length)}
+                    {quickFilter ? ` / ${formatNumber(locale, activeResult.rows.length)}` : ''} {t('rowsLabel')}
+                  </span>
+                  {canPaginate ? (
+                    <>
+                      <span style={{ opacity: 0.4 }}>│</span>
+                      <span>{t('pageOf', { page: currentPage, total: totalPages })}</span>
+                    </>
+                  ) : null}
+                  <span style={{ opacity: 0.4 }}>│</span>
+                </>
               ) : null}
-              {hasGridResult ? <span>{t('totalRecords', { count: formatNumber(locale, totalRows) })}</span> : null}
-              {canPaginate ? <span>{t('pageOf', { page: currentPage, total: totalPages })}</span> : null}
-              <span>{activeResult.execution_time}ms</span>
+              <span style={{ color: connectionColor }}>{activeResult.execution_time}ms</span>
             </div>
             {transactionOpen ? (
               <>
@@ -1078,7 +1131,22 @@ export default function QueryWorkspace() {
       </div>
 
       <div className="flex-1 overflow-auto bg-background/10 relative">
-        {loading ? (
+        {activePanel === 'logs' ? (
+          <div className="h-full overflow-y-auto p-3" style={{ fontFamily: 'ui-monospace, "SF Mono", monospace', fontSize: 11.5 }}>
+            {resolvedConnectionId && connectionLogs[resolvedConnectionId]?.length ? (
+              connectionLogs[resolvedConnectionId].map((entry, i) => (
+                <div key={i} className="py-1 border-b border-border/30 last:border-0" style={{ color: 'var(--bt-muted)', lineHeight: 1.6 }}>
+                  {entry}
+                </div>
+              ))
+            ) : (
+              <div className="flex h-full items-center justify-center text-muted/50 text-sm" style={{ fontFamily: 'inherit' }}>
+                Nenhum log registrado para esta conexão.
+              </div>
+            )}
+          </div>
+        ) : null}
+        {activePanel === 'results' && loading ? (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/55 backdrop-blur-[1px]">
             <div className="flex items-center gap-3">
               <LoaderCircle size={16} className="animate-spin text-primary" />
@@ -1088,9 +1156,9 @@ export default function QueryWorkspace() {
             </div>
           </div>
         ) : null}
-        {error && !loading ? (
+        {activePanel === 'results' && error && !loading ? (
           <QueryErrorPanel error={error} activeSchema={schemaLabel} onRetry={() => void executeQuery()} />
-        ) : activeResult ? (
+        ) : activePanel === 'results' && activeResult ? (
           <div className="flex h-full min-h-0 flex-col">
             {activeResult.summary ? (
               <div className="border-b border-border/60 bg-emerald-400/5 px-4 py-3 text-xs text-emerald-100/90">
@@ -1122,11 +1190,11 @@ export default function QueryWorkspace() {
               )}
             </div>
           </div>
-        ) : (
+        ) : activePanel === 'results' ? (
           <div className="h-full flex items-center justify-center text-muted/50 text-sm">
             {t('runQueryToSeeResults')}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );
@@ -1144,18 +1212,29 @@ export default function QueryWorkspace() {
         ) : null}
 
         <div className="relative z-10 flex h-full min-h-0 flex-col gap-3">
-          <div className="shrink-0 overflow-hidden rounded-lg border border-border/80 glass-panel shadow-[0_18px_48px_rgba(0,0,0,0.22)]">
-            <div className="flex items-center overflow-x-auto scrollbar-hide border-b border-border/70 bg-background/16">
-              {tabs.map(tab => (
+          <div className="shrink-0 overflow-hidden">
+            <div className="flex items-stretch overflow-x-auto scrollbar-hide" style={{ background: 'rgba(10,20,32,0.4)' }}>
+              {tabs.map(tab => {
+                const tabColor = getConnectionColor(connections, tab.connectionId ?? activeConnectionId);
+                return (
                 <div
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`group flex items-center gap-2 px-3 py-3 border-r border-border/70 min-w-[148px] max-w-[240px] cursor-pointer select-none rounded-t-lg border-b-2 transition-colors ${
-                    activeTabId === tab.id
-                      ? 'bg-background/80 text-primary border-b-primary'
-                      : 'text-muted border-b-transparent hover:bg-border/20'
+                  className={`group relative flex items-center gap-2 px-3 py-2.5 border-r border-border/60 min-w-[148px] max-w-[240px] cursor-pointer select-none transition-colors ${
+                    activeTabId === tab.id ? 'text-text' : 'text-muted hover:bg-white/4'
                   }`}
+                  style={{
+                    background: activeTabId === tab.id ? 'var(--bt-surface)' : 'transparent',
+                    borderBottom: activeTabId === tab.id ? '1px solid var(--bt-surface)' : '1px solid var(--bt-border)',
+                  }}
                 >
+                  {activeTabId === tab.id && (
+                    <div style={{
+                      position: 'absolute', top: 0, left: 0, right: 0, height: 2,
+                      background: tabColor, boxShadow: `0 0 10px ${tabColor}`,
+                    }} />
+                  )}
+                  <span style={{ width: 6, height: 6, borderRadius: 2, flexShrink: 0, background: tabColor, opacity: activeTabId === tab.id ? 1 : 0.5 }} />
                   <span className="text-sm truncate flex-1">{tab.title}</span>
                   <button
                     onClick={(e) => { e.stopPropagation(); closeTab(tab.id); }}
@@ -1166,38 +1245,46 @@ export default function QueryWorkspace() {
                     <X size={14} />
                   </button>
                 </div>
-              ))}
-              <div className="ml-auto mr-2 flex shrink-0 items-center gap-2">
-                <button
-                  onClick={() => addTab(resolvedConnectionId)}
-                  className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-dashed border-border/60 px-3 py-2 text-xs font-medium text-muted hover:text-text hover:border-primary/50 hover:bg-primary/6 transition-colors"
-                >
-                  <Plus size={15} />
-                  <span className="hidden sm:inline">{t('newQueryTab')}</span>
-                  <span className="sm:hidden">{t('newQuery')}</span>
-                </button>
-              </div>
+                );
+              })}
+              <button
+                onClick={() => addTab(resolvedConnectionId)}
+                className="flex flex-1 items-center px-3 text-muted hover:text-text transition-colors"
+                style={{ borderBottom: '1px solid var(--bt-border)', minWidth: 40, paddingTop: 10, paddingBottom: 10 }}
+                title={t('newQueryTab')}
+              >
+                <Plus size={14} />
+              </button>
             </div>
 
-            <div className="px-3 py-2.5 flex flex-wrap items-center gap-2">
+            <div className="px-3 py-2.5 flex flex-wrap items-center gap-2" style={{ background: 'var(--bt-surface)', borderBottom: '1px solid var(--bt-border)' }}>
               <button
                 onClick={() => void executeQuery()}
                 disabled={loading || !activeTab || !resolvedConnectionId}
-                className="flex items-center gap-1.5 bg-emerald-400/18 text-emerald-200 hover:bg-emerald-400/26 px-3.5 py-1.5 rounded-lg text-sm font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed border border-emerald-400/35 shadow-[0_0_18px_rgba(16,185,129,0.18)] hover:shadow-[0_0_24px_rgba(16,185,129,0.28)]"
+                className="flex items-center gap-2 px-4 py-1.5 rounded-lg text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{
+                  background: connectionColor,
+                  color: '#08111A',
+                  border: 'none',
+                  letterSpacing: 0.4,
+                  boxShadow: `0 0 18px ${hexToRgba(connectionColor, 0.50)}, inset 0 1px 0 rgba(255,255,255,0.20)`,
+                }}
               >
-                {loading ? <LoaderCircle size={14} className="animate-spin" /> : <Play size={14} className="fill-green-400/50" />}
+                {loading
+                  ? <LoaderCircle size={14} className="animate-spin" style={{ color: '#08111A' }} />
+                  : <Play size={14} style={{ fill: '#08111A', opacity: 0.75 }} />
+                }
                 {t('run')}
+                <span style={{ opacity: 0.5, fontFamily: 'ui-monospace, monospace', fontSize: 10 }}>⌘↵</span>
               </button>
-              <span className="rounded-full border border-border/70 bg-background/22 px-2.5 py-1 text-[11px] text-muted">
-                Cmd+Enter
-              </span>
               <button
                 onClick={toggleHistory}
-                className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
-                  historyOpen
-                    ? 'border-primary/40 bg-primary/10 text-primary'
-                    : 'border-border text-muted hover:bg-border/30 hover:text-text'
-                }`}
+                className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors"
+                style={{
+                  background: historyOpen ? hexToRgba(connectionColor, 0.12) : 'var(--bt-surface)',
+                  border: `1px solid ${historyOpen ? hexToRgba(connectionColor, 0.35) : 'var(--bt-border)'}`,
+                  color: historyOpen ? connectionColor : 'var(--bt-muted)',
+                }}
               >
                 <Clock3 size={13} />
                 {t('history')}
@@ -1207,12 +1294,10 @@ export default function QueryWorkspace() {
                   ref={connectionMenuButtonRef}
                   type="button"
                   onClick={toggleConnectionMenu}
-                  className={`flex w-full min-w-0 sm:min-w-[240px] items-center gap-2 rounded-lg border px-2 py-1.5 text-left transition-colors ${
-                    connectionMenuOpen
-                      ? 'border-primary/40 bg-background/40'
-                      : 'border-border/70 bg-background/22 hover:bg-border/30'
-                  }`}
+                  className="flex w-full min-w-0 sm:min-w-[240px] items-center gap-2 rounded-lg border px-2 py-1.5 text-left transition-colors border-border/70 bg-background/22 hover:bg-border/30"
+                  style={connectionMenuOpen ? { borderColor: hexToRgba(connectionColor, 0.45) } : undefined}
                 >
+                  <span style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: connectionColor, boxShadow: `0 0 6px ${hexToRgba(connectionColor, 0.8)}` }} />
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-[11px] uppercase tracking-[0.14em] text-muted">
                       {selectedConnection ? `${selectedConnection.engine.toUpperCase()} - ${selectedConnection.name}` : t('noActiveConnection')}
@@ -1234,7 +1319,14 @@ export default function QueryWorkspace() {
             </div>
           </div>
 
-          <div className="flex-1 relative min-h-0 flex flex-col overflow-hidden rounded-lg border border-border/80 glass-panel shadow-[0_18px_48px_rgba(0,0,0,0.24)]">
+          <div
+            className="flex-1 relative min-h-0 flex flex-col overflow-hidden rounded-lg glass-panel shadow-[0_18px_48px_rgba(0,0,0,0.24)]"
+            style={{
+              border: `1px solid ${hexToRgba(connectionColor, 0.28)}`,
+              borderLeft: `2px solid ${connectionColor}`,
+              boxShadow: `0 18px 48px rgba(0,0,0,0.24), inset 4px 0 18px -4px ${hexToRgba(connectionColor, 0.10)}`,
+            }}
+          >
             {activeTab ? (
               <div className="flex-1 min-h-[220px] overflow-hidden rounded-lg bg-background/30">
                 <Editor

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -182,8 +182,11 @@ export default function ResultGrid({
           position: 'relative',
         }}
       >
-        <div className="flex bg-surface/95 backdrop-blur text-xs text-muted sticky top-0 z-10 border-b border-border/90 shadow-[0_8px_24px_rgba(0,0,0,0.18)]" style={{ height: headerHeight }}>
-          <div className="w-14 px-2 py-2 text-center sticky left-0 bg-surface/95 select-none opacity-50 shrink-0 border-r border-border/50">
+        <div
+          className="sticky top-0 z-10 flex border-b border-border/80 bg-[#0c1621]/95 text-[11px] text-muted shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur"
+          style={{ height: headerHeight }}
+        >
+          <div className="sticky left-0 w-12 shrink-0 select-none border-r border-border/35 bg-[#0c1621]/95 px-2 py-2 text-center opacity-45">
             #
           </div>
           {columns.map((col, idx) => {
@@ -191,16 +194,16 @@ export default function ResultGrid({
             return (
               <div
                 key={idx}
-                className="relative border-r border-border/50"
+                className="relative border-r border-border/35"
                 style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
               >
                 <div
-                  className="px-3 py-1.5 leading-tight whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer select-none hover:bg-border/20"
+                  className="cursor-pointer select-none overflow-hidden whitespace-nowrap px-3 py-1.5 leading-tight text-ellipsis hover:bg-background/28"
                   onClick={() => handleSortToggle(col.name)}
                   title={`Ordenar por ${col.name}`}
                 >
                   <div className="flex items-center gap-1.5 overflow-hidden">
-                    <span className={`overflow-hidden text-ellipsis text-sm font-medium normal-case tracking-normal ${isSorted ? 'text-primary' : 'text-text'}`}>
+                    <span className={`overflow-hidden text-ellipsis font-mono text-[12px] normal-case tracking-normal ${isSorted ? 'text-primary' : 'text-text/92'}`}>
                       {col.name}
                     </span>
                     {isSorted ? (
@@ -246,17 +249,21 @@ export default function ResultGrid({
           })}
         </div>
         
-        <div className="absolute w-full divide-y divide-border/30" style={{ top: `${headerHeight}px` }}>
+        <div className="absolute w-full" style={{ top: `${headerHeight}px` }}>
           {rowVirtualizer.getVirtualItems().map((virtualRow) => {
             const row = sortedRows[virtualRow.index];
-            const rowTone = virtualRow.index % 2 === 0 ? 'bg-[#0A1321]' : 'bg-[#0D1726]';
+            const rowTone = virtualRow.index % 2 === 0 ? 'bg-[#09131d]' : 'bg-[#0b1520]';
             const isThisRowLocked = lockedRowIndex === virtualRow.index;
             const isSelectedRow = selectedRowIndex === virtualRow.index;
             return (
               <div
                 key={virtualRow.key}
-                className={`group absolute w-full flex text-sm transition-colors ${rowTone} ${
-                  isSelectedRow ? 'ring-1 ring-inset ring-sky-400/45 bg-sky-400/8' : isThisRowLocked ? 'ring-1 ring-inset ring-primary/30' : 'hover:bg-primary/10'
+                className={`group absolute flex w-full border-b border-border/20 text-sm transition-colors ${rowTone} ${
+                  isSelectedRow
+                    ? 'ring-1 ring-inset ring-primary/35 bg-primary/6'
+                    : isThisRowLocked
+                      ? 'ring-1 ring-inset ring-primary/25'
+                      : 'hover:bg-[#0e1a27]'
                 }`}
                 style={{
                   height: `${virtualRow.size}px`,
@@ -266,10 +273,10 @@ export default function ResultGrid({
                 <button
                   type="button"
                   onClick={() => onRowSelect?.(virtualRow.index, row as Record<string, unknown>)}
-                  className={`w-14 px-2 flex items-center justify-center border-r border-border/20 text-xs font-mono sticky left-0 shrink-0 transition-colors ${
+                  className={`sticky left-0 flex w-12 shrink-0 items-center justify-center border-r border-border/25 px-2 text-xs font-mono transition-colors ${
                     isSelectedRow
-                      ? 'text-sky-200 bg-sky-400/10'
-                      : `${rowTone} text-muted/50 ${isThisRowLocked ? '' : 'group-hover:bg-primary/10'}`
+                      ? 'bg-primary/8 text-primary'
+                      : `${rowTone} text-muted/45 ${isThisRowLocked ? '' : 'group-hover:bg-[#0e1a27]'}`
                   }`}
                   title="Selecionar linha"
                 >
@@ -289,7 +296,7 @@ export default function ResultGrid({
                       key={cIdx}
                       onClick={() => handleCellClick(cellKey, val, virtualRow.index)}
                       onDoubleClick={() => openEdit(cellKey, val)}
-                      className={`px-3 flex items-center gap-1.5 whitespace-nowrap overflow-hidden border-r border-border/20 font-mono transition-colors ${
+                      className={`flex items-center gap-1.5 overflow-hidden whitespace-nowrap border-r border-border/20 px-3.5 font-mono text-[13px] transition-colors ${
                         isEditing
                           ? 'bg-primary/10 outline outline-1 outline-primary/60 p-0'
                           : isPendingEdit
@@ -297,10 +304,10 @@ export default function ResultGrid({
                             : hasEditError
                               ? 'bg-red-400/12 text-red-100'
                               : isInactiveCell
-                                ? 'opacity-35 pointer-events-none select-none text-text'
+                                ? 'pointer-events-none select-none text-text opacity-35'
                                 : isCopied
                                   ? 'bg-emerald-400/16 text-emerald-100'
-                                  : 'text-text cursor-pointer text-ellipsis'
+                                  : 'cursor-pointer text-ellipsis text-text/94'
                       }`}
                       style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
                       title={hasEditError ? editError : displayValue}

--- a/src/index.css
+++ b/src/index.css
@@ -5,23 +5,20 @@
 @layer base {
   :root {
     color-scheme: var(--bt-color-scheme, dark);
-    --bt-background: #0b0f14;
-    --bt-background-rgb: 11 15 20;
-    --bt-surface: #10171f;
-    --bt-surface-rgb: 16 23 31;
-    --bt-border: #1d2a34;
-    --bt-border-rgb: 29 42 52;
-    --bt-primary: #2bd3c9;
-    --bt-primary-rgb: 43 211 201;
-    --bt-text: #e6edf3;
-    --bt-text-rgb: 230 237 243;
-    --bt-muted: #88a0af;
-    --bt-muted-rgb: 136 160 175;
-    --bt-body-background:
-      radial-gradient(circle at top center, rgba(43, 211, 201, 0.16), transparent 34%),
-      radial-gradient(circle at 18% 18%, rgba(43, 211, 201, 0.08), transparent 24%),
-      linear-gradient(180deg, #0d1218 0%, #0b0f14 48%, #090d11 100%);
-    --bt-glass-panel: rgba(16, 23, 31, 0.8);
+    --bt-background: #08111a;
+    --bt-background-rgb: 8 17 26;
+    --bt-surface: #0d1824;
+    --bt-surface-rgb: 13 24 36;
+    --bt-border: #1a2c3c;
+    --bt-border-rgb: 26 44 60;
+    --bt-primary: #47c4e8;
+    --bt-primary-rgb: 71 196 232;
+    --bt-text: #edf4fb;
+    --bt-text-rgb: 237 244 251;
+    --bt-muted: #8aa3b6;
+    --bt-muted-rgb: 138 163 182;
+    --bt-body-background: #08111a;
+    --bt-glass-panel: rgba(13, 24, 36, 0.85);
   }
 
   html,

--- a/src/store/connections.ts
+++ b/src/store/connections.ts
@@ -35,6 +35,30 @@ export interface ConnectionConfig {
   ssh?: SshConfig;
 }
 
+export const CONNECTION_COLOR_PALETTE = [
+  '#3ECF8E',
+  '#47C4E8',
+  '#7B6BFF',
+  '#FFB547',
+  '#E86A4E',
+  '#FF6B9D',
+  '#4ECDC4',
+  '#95E06C',
+];
+
+export function getConnectionColor(connections: ConnectionConfig[], connId: string | null | undefined): string {
+  if (!connId) return '#47C4E8';
+  const idx = connections.findIndex((c) => c.id === connId);
+  return idx === -1 ? '#47C4E8' : CONNECTION_COLOR_PALETTE[idx % CONNECTION_COLOR_PALETTE.length];
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 interface ConnectionsState {
   connections: ConnectionConfig[];
   activeConnectionId: string | null;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -22,15 +22,14 @@ export const APP_THEMES: AppThemeDefinition[] = [
     label: 'PulseSQL Dark',
     mode: 'dark',
     colors: {
-      background: '#0B0F14',
-      surface: '#10171F',
-      border: '#1D2A34',
-      primary: '#2BD3C9',
-      text: '#E6EDF3',
-      muted: '#88A0AF',
-      bodyBackground:
-        'radial-gradient(circle at top center, rgba(43, 211, 201, 0.16), transparent 34%), radial-gradient(circle at 16% 18%, rgba(43, 211, 201, 0.08), transparent 22%), linear-gradient(180deg, #0d1218 0%, #0b0f14 54%, #090d11 100%)',
-      glassPanel: 'rgba(16, 23, 31, 0.8)',
+      background: '#08111A',
+      surface: '#0D1824',
+      border: '#1A2C3C',
+      primary: '#47C4E8',
+      text: '#EDF4FB',
+      muted: '#8AA3B6',
+      bodyBackground: '#08111A',
+      glassPanel: 'rgba(13, 24, 36, 0.85)',
     },
   },
   {


### PR DESCRIPTION
## Summary

- Full ATLAS visual theme: new color palette (`#08111A` background, surface, border, text), flat ambient connection wash, custom TitleBar with macOS traffic light clearance (76px)
- Sidebar redesigned: ATLAS-style `CONNECTIONS` header with horizontal rule + count, connection items with 3px left indicator bar + glow + engine badge (PG/MY/ORA)
- Tab strip: flat `rgba(10,20,32,0.4)` background, active tab gets 2px top glow indicator in connection color
- Run button: solid connection color (not tinted), dark text, glow shadow
- Result area: pill-style tabs inside a container, execution stats colored with connection color
- Status bar: monospace, uppercase, structured (`● ConnName · PG · 42ms`)
- Logs tab added directly in the result grid pill tabs — removes the separate toolbar Logs button

## Test plan

- [ ] Open a connection and verify ambient wash color matches the connection
- [ ] Check TitleBar traffic lights are not overlapped (76px clearance)
- [ ] Verify Logs tab shows connection log entries and switches back to Results on next query run
- [ ] Run a query and confirm pill tabs, row count, and execution time render correctly
- [ ] Check sidebar left bar glow on active connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)