### PR TITLE
chore: bump version to 0.2.0-1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-1",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Pre-release version bump. Uses numeric-only pre-release identifier (`0.2.0-1`) required by WiX MSI bundler on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)