### PR TITLE
chore: detect any pre-release suffix for GitHub pre-release flag

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Publish release
         run: |
-          if [[ "${{ github.ref_name }}" == *"-rc"* ]] || [[ "${{ github.ref_name }}" == *"-beta"* ]]; then
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
             gh release edit "${{ github.ref_name }}" --draft=false --prerelease
           else
             gh release edit "${{ github.ref_name }}" --draft=false


### PR DESCRIPTION
Fixes pre-release detection in publish-release step.

Previously only checked for `-rc` or `-beta` in tag name. Now matches any `vX.Y.Z-<suffix>` pattern (including numeric-only like `v0.2.0-1`, required by WiX MSI bundler on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)