### PR TITLE
feat: ATLAS Bloco 0 + Bloco 1 — color picker + toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.23",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-opener": "^2",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -1523,6 +1524,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-clipboard-manager": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.2.tgz",
+      "integrity": "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^1.8.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "sql-formatter": "^15.7.3",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.12"
       },
@@ -1675,6 +1676,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -1924,6 +1931,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -2352,6 +2365,12 @@
         "marked": "14.0.0"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2389,6 +2408,34 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -2658,6 +2705,25 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -2744,6 +2810,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/reusify": {
@@ -2850,6 +2925,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.3.tgz",
+      "integrity": "sha512-5+zl9Nqg5aNjss0tb1G+StpC4dJKbjv3+g8CL/+V+00PfZop+2RKGyi53ScFl0dr+Dkx1LjmUO54Q3N7K3EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/state-local": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^1.8.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "sql-formatter": "^15.7.3",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-opener": "^2",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8.6", features = ["postgres", "mysql", "sqlite", "runtime-tokio-rustls", "json", "chrono"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "opener:default",
     "updater:default",
     "process:default",
-    "clipboard-manager:allow-read-text"
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "clipboard-manager:allow-read-text"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,6 +272,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .invoke_handler(tauri::generate_handler![
             greet,
             update_splash_progress,

--- a/src/features/connections/ConnectionForm.tsx
+++ b/src/features/connections/ConnectionForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { CheckCircle, Eye, EyeOff, LoaderCircle, XCircle } from 'lucide-react';
 import { createDefaultConnectionForm, ENGINE_DEFINITIONS } from './connection-engines';
-import { ConnectionConfig, DatabaseEngine, OracleConnectionType, PostgresSslMode, SshAuthMethod, useConnectionsStore } from '../../store/connections';
+import { CONNECTION_COLOR_PALETTE, ConnectionConfig, DatabaseEngine, OracleConnectionType, PostgresSslMode, SshAuthMethod, useConnectionsStore } from '../../store/connections';
 import AppSelect from '../../components/ui/AppSelect';
 import JdkSetupBanner from './JdkSetupBanner';
 
@@ -227,13 +227,47 @@ export default function ConnectionForm({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm text-muted mb-1">Connection Name</label>
-            <input
-              value={formData.name}
-              onChange={(event) => updateField('name', event.target.value)}
-              className="w-full bg-background border border-border rounded px-3 py-2 text-sm focus:border-primary focus:outline-none"
-              placeholder="Production DB"
-              required
-            />
+            <div className="flex items-center gap-2">
+              <input
+                value={formData.name}
+                onChange={(event) => updateField('name', event.target.value)}
+                className="flex-1 bg-background border border-border rounded px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                placeholder="Production DB"
+                required
+              />
+              <div className="relative flex-shrink-0">
+                <div
+                  className="w-8 h-8 rounded-md border-2 border-border cursor-pointer flex items-center justify-center overflow-hidden"
+                  style={{ borderColor: formData.color ?? '#47C4E8', background: (formData.color ?? '#47C4E8') + '22' }}
+                  title="Connection color"
+                >
+                  <input
+                    type="color"
+                    value={formData.color ?? '#47C4E8'}
+                    onChange={(e) => updateField('color', e.target.value)}
+                    className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                    style={{ width: '200%', height: '200%', transform: 'translate(-25%, -25%)' }}
+                  />
+                  <div className="w-3.5 h-3.5 rounded-sm" style={{ background: formData.color ?? '#47C4E8' }} />
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-1.5 mt-2">
+              {CONNECTION_COLOR_PALETTE.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => updateField('color', c)}
+                  className="w-5 h-5 rounded-sm transition-transform hover:scale-110"
+                  style={{
+                    background: c,
+                    outline: formData.color === c ? `2px solid ${c}` : 'none',
+                    outlineOffset: 2,
+                  }}
+                  title={c}
+                />
+              ))}
+            </div>
           </div>
           <div>
             <label className="block text-sm text-muted mb-1">Database Engine</label>

--- a/src/features/connections/ConnectionManager.tsx
+++ b/src/features/connections/ConnectionManager.tsx
@@ -684,7 +684,8 @@ export default function ConnectionManager() {
                 </div>
               ) : (
                 <>
-                  <div className="shrink-0 space-y-1.5">
+                  <div className="shrink-0 overflow-y-auto max-h-[calc(100%_-_148px)]">
+                    <div className="space-y-1.5">
                     {connections.map((conn) => {
                       const connectionState = resolveConnectionState(conn.id);
                       const isActiveCard = activeConnectionId === conn.id;
@@ -807,22 +808,23 @@ export default function ConnectionManager() {
                         </button>
                       );
                     })}
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingConnectionId(null);
+                        setShowForm(true);
+                      }}
+                      className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border/60 px-4 py-3 text-sm text-muted transition-colors hover:border-primary/45 hover:bg-primary/6 hover:text-text"
+                      title={t('newConnection')}
+                    >
+                      <Plus size={14} />
+                      {t('newConnection')}
+                    </button>
                   </div>
 
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingConnectionId(null);
-                      setShowForm(true);
-                    }}
-                    className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border/60 px-4 py-3 text-sm text-muted transition-colors hover:border-primary/45 hover:bg-primary/6 hover:text-text"
-                    title={t('newConnection')}
-                  >
-                    <Plus size={14} />
-                    {t('newConnection')}
-                  </button>
-
-                  <div className="mt-3 min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-background/18">
+                  <div className="mt-3 min-h-[120px] flex-1 overflow-hidden rounded-xl border border-border/70 bg-background/18">
                     {activeConnection ? (
                       <DatabaseExplorer
                         connId={activeConnection.id}

--- a/src/features/connections/ConnectionManager.tsx
+++ b/src/features/connections/ConnectionManager.tsx
@@ -23,7 +23,7 @@ import tauriConfig from '../../../src-tauri/tauri.conf.json';
 import changelog from '../../../CHANGELOG.md?raw';
 import oracleMark from '../../assets/oracle-mark.svg';
 import postgresMark from '../../assets/postgres-mark.svg';
-import { ConnectionConfig, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
+import { ConnectionConfig, CONNECTION_COLOR_PALETTE, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { useConnectionRuntimeStore, type RuntimeConnectionState } from '../../store/connectionRuntime';
 import { useDatabaseSessionStore } from '../../store/databaseSession';
 import { useUiPreferencesStore } from '../../store/uiPreferences';
@@ -61,7 +61,7 @@ type WorkspaceMetricsPayload = {
 };
 
 export default function ConnectionManager() {
-  const { connections, activeConnectionId, favoriteConnectionId, addConnection, removeConnection, setActiveConnection, setFavoriteConnection } =
+  const { connections, activeConnectionId, favoriteConnectionId, addConnection, updateConnection, removeConnection, setActiveConnection, setFavoriteConnection } =
     useConnectionsStore();
   const activeSchema = useDatabaseSessionStore(
     (state) => (activeConnectionId ? state.activeSchemaByConnection[activeConnectionId] ?? null : null),
@@ -116,6 +116,7 @@ export default function ConnectionManager() {
   const [exportSelectedIds, setExportSelectedIds] = useState<Set<string>>(new Set());
   const [exportSavedPath, setExportSavedPath] = useState<string | null>(null);
   const [removeConfirmConn, setRemoveConfirmConn] = useState<ConnectionConfig | null>(null);
+  const [colorPickerConnId, setColorPickerConnId] = useState<string | null>(null);
 
   const activeConnection =
     connections.find((connection) => connection.id === activeConnectionId) ?? null;
@@ -533,6 +534,9 @@ export default function ConnectionManager() {
 
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden">
+      {colorPickerConnId ? (
+        <div className="fixed inset-0 z-40" onMouseDown={() => setColorPickerConnId(null)} />
+      ) : null}
       <div
         style={{
           position: 'absolute',
@@ -745,21 +749,60 @@ export default function ConnectionManager() {
                                 {conn.host}{conn.database ? `/${conn.database}` : ''}
                               </div>
                             </div>
-                            <span
-                              style={{
-                                padding: '2px 6px',
-                                borderRadius: 5,
-                                fontSize: 9,
-                                fontWeight: 700,
-                                letterSpacing: 0.5,
-                                color: connColor,
-                                border: `1px solid ${hexToRgba(connColor, 0.3)}`,
-                                background: hexToRgba(connColor, 0.1),
-                                flexShrink: 0,
-                              }}
-                            >
-                              {conn.engine === 'oracle' ? 'ORA' : conn.engine === 'mysql' ? 'MY' : 'PG'}
-                            </span>
+                            <div className="relative flex-shrink-0">
+                              <button
+                                type="button"
+                                onClick={(e) => { e.stopPropagation(); setColorPickerConnId(colorPickerConnId === conn.id ? null : conn.id); }}
+                                title="Change connection color"
+                                style={{
+                                  padding: '2px 6px',
+                                  borderRadius: 5,
+                                  fontSize: 9,
+                                  fontWeight: 700,
+                                  letterSpacing: 0.5,
+                                  color: connColor,
+                                  border: `1px solid ${hexToRgba(connColor, 0.3)}`,
+                                  background: hexToRgba(connColor, 0.1),
+                                  cursor: 'pointer',
+                                }}
+                              >
+                                {conn.engine === 'oracle' ? 'ORA' : conn.engine === 'mysql' ? 'MY' : 'PG'}
+                              </button>
+                              {colorPickerConnId === conn.id && (
+                                <div
+                                  className="absolute right-0 top-7 z-50 rounded-lg border border-border bg-surface p-2 shadow-xl"
+                                  style={{ width: 160 }}
+                                  onClick={(e) => e.stopPropagation()}
+                                  onMouseDown={(e) => e.stopPropagation()}
+                                >
+                                  <div className="flex flex-wrap gap-1.5 mb-2">
+                                    {CONNECTION_COLOR_PALETTE.map((c) => (
+                                      <button
+                                        key={c}
+                                        type="button"
+                                        onClick={() => { updateConnection({ ...conn, color: c }); setColorPickerConnId(null); }}
+                                        className="w-6 h-6 rounded-md transition-transform hover:scale-110"
+                                        style={{
+                                          background: c,
+                                          outline: connColor === c ? `2px solid ${c}` : 'none',
+                                          outlineOffset: 2,
+                                        }}
+                                      />
+                                    ))}
+                                  </div>
+                                  <div className="relative flex items-center gap-1.5 rounded-md border border-border px-2 py-1 cursor-pointer hover:bg-background/40">
+                                    <div className="w-4 h-4 rounded-sm flex-shrink-0" style={{ background: connColor }} />
+                                    <span className="text-xs text-muted font-mono flex-1">{connColor}</span>
+                                    <input
+                                      type="color"
+                                      value={connColor}
+                                      onChange={(e) => updateConnection({ ...conn, color: e.target.value })}
+                                      className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                                    />
+                                  </div>
+                                </div>
+                              )}
+                            </div>
                           </div>
                         </button>
                       );
@@ -900,6 +943,21 @@ export default function ConnectionManager() {
           >
             <PlugZap size={14} className="text-muted" />
             <span>{t('disconnect')}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const connId = connectionContextMenu.connId;
+              setConnectionContextMenu(null);
+              setColorPickerConnId(connId);
+            }}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-text transition-colors hover:bg-background/55"
+          >
+            <span
+              className="h-3.5 w-3.5 rounded-sm flex-shrink-0"
+              style={{ background: getConnectionColor(connections, connectionContextMenu.connId) }}
+            />
+            <span>Change color…</span>
           </button>
           <div className="my-1 border-t border-border/70" />
           <button

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { format as sqlFormat } from 'sql-formatter';
-import { readText as clipboardReadText } from '@tauri-apps/plugin-clipboard-manager';
+import { readText as clipboardReadText, writeText as clipboardWriteText } from '@tauri-apps/plugin-clipboard-manager';
 import { useQueriesStore } from '../../store/queries';
 import { type DatabaseEngine, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { invoke } from '@tauri-apps/api/core';
@@ -1437,15 +1437,42 @@ export default function QueryWorkspace() {
                   }}
                   onMount={(editor, monaco) => {
                     editorRef.current = editor;
-                    // Tauri WKWebView blocks navigator.clipboard; intercept Cmd+V via onKeyDown
-                    // and read clipboard through the official Tauri plugin.
+                    // Tauri WKWebView blocks navigator.clipboard; intercept copy/cut/paste
+                    // via onKeyDown and use the official Tauri clipboard plugin.
                     editor.onKeyDown((e) => {
-                      if (e.keyCode === monaco.KeyCode.KeyV && (e.ctrlKey || e.metaKey)) {
+                      const model = editor.getModel();
+                      const sel = editor.getSelection();
+                      if (!model || !sel) return;
+
+                      if (e.keyCode === monaco.KeyCode.KeyC && (e.ctrlKey || e.metaKey)) {
                         e.preventDefault();
                         e.stopPropagation();
-                        const sel = editor.getSelection();
-                        const model = editor.getModel();
-                        if (!sel || !model) return;
+                        const text = sel.isEmpty()
+                          ? model.getLineContent(sel.startLineNumber)
+                          : model.getValueInRange(sel);
+                        void clipboardWriteText(text);
+                      } else if (e.keyCode === monaco.KeyCode.KeyX && (e.ctrlKey || e.metaKey)) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (sel.isEmpty()) {
+                          const line = sel.startLineNumber;
+                          void clipboardWriteText(model.getLineContent(line));
+                          editor.pushUndoStop();
+                          editor.executeEdits('cut', [{
+                            range: new monaco.Range(line, 1, line + 1, 1),
+                            text: '',
+                            forceMoveMarkers: true,
+                          }]);
+                          editor.pushUndoStop();
+                        } else {
+                          void clipboardWriteText(model.getValueInRange(sel));
+                          editor.pushUndoStop();
+                          editor.executeEdits('cut', [{ range: sel, text: '', forceMoveMarkers: true }]);
+                          editor.pushUndoStop();
+                        }
+                      } else if (e.keyCode === monaco.KeyCode.KeyV && (e.ctrlKey || e.metaKey)) {
+                        e.preventDefault();
+                        e.stopPropagation();
                         void clipboardReadText().then((text) => {
                           if (!text) return;
                           editor.pushUndoStop();

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1436,20 +1436,25 @@ export default function QueryWorkspace() {
                   }}
                   onMount={(editor, monaco) => {
                     editorRef.current = editor;
-                    // Tauri WKWebView blocks navigator.clipboard.readText(); intercept native paste events directly
-                    const domNode = editor.getDomNode();
-                    if (domNode) {
-                      domNode.addEventListener('paste', (e: ClipboardEvent) => {
-                        const text = e.clipboardData?.getData('text/plain');
-                        if (!text) return;
-                        e.stopPropagation();
-                        e.preventDefault();
-                        const sel = editor.getSelection();
-                        const model = editor.getModel();
-                        if (!model) return;
-                        editor.executeEdits('paste', [{ range: sel ?? model.getFullModelRange(), text, forceMoveMarkers: true }]);
-                      }, true);
-                    }
+                    // Tauri WKWebView: navigator.clipboard.readText() fails outside user-gesture context.
+                    // Override Cmd+V with a sync execCommand approach via a temp textarea.
+                    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
+                      const sel = editor.getSelection();
+                      const model = editor.getModel();
+                      if (!sel || !model) return;
+                      const ta = document.createElement('textarea');
+                      ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;';
+                      document.body.appendChild(ta);
+                      ta.focus();
+                      document.execCommand('paste');
+                      const text = ta.value;
+                      ta.remove();
+                      editor.focus();
+                      if (!text) return;
+                      editor.pushUndoStop();
+                      editor.executeEdits('paste', [{ range: sel, text, forceMoveMarkers: true }]);
+                      editor.pushUndoStop();
+                    });
                     autocompleteDisposableRef.current?.dispose();
                     autocompleteDisposableRef.current = registerSqlAutocomplete(monaco, () => autocompleteContextRef.current);
                     lastCursorPositionRef.current = editor.getPosition();

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor from '@monaco-editor/react';
+import { format as sqlFormat } from 'sql-formatter';
 import { useQueriesStore } from '../../store/queries';
 import { type DatabaseEngine, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { invoke } from '@tauri-apps/api/core';
@@ -25,6 +26,8 @@ import {
   Trash2,
   Maximize2,
   Minimize2,
+  AlignLeft,
+  Sparkles,
 } from 'lucide-react';
 import ResultGrid from './ResultGrid';
 import QueryHistoryDrawer from '../history/components/QueryHistoryDrawer';
@@ -79,6 +82,7 @@ const SEMANTIC_SUCCESS_DURATION_MS = 3600;
 const SEMANTIC_ERROR_DURATION_MS = 6200;
 const SEMANTIC_WARNING_DURATION_MS = 6200;
 const CONNECTION_MENU_WIDTH = 340;
+let sqlFormatterRegistered = false;
 
 export default function QueryWorkspace() {
   const {
@@ -128,6 +132,16 @@ export default function QueryWorkspace() {
   const isConnectionReady = runtimeStatus === 'connected';
   const transactionOpen = resolvedConnectionId ? transactionOpenByConnection[resolvedConnectionId] === true : false;
   const activeConnectionLogCount = resolvedConnectionId ? (connectionLogs[resolvedConnectionId]?.length ?? 0) : 0;
+
+  const toolbarStatus: { label: string; color: string; pulse: boolean } | null = useMemo(() => {
+    const tr = (key: Parameters<typeof translate>[1]) => translate(locale, key);
+    if (semanticBackgroundState === 'running') return { label: tr('statusRunning'), color: connectionColor, pulse: true };
+    if (semanticBackgroundState === 'success') return { label: tr('statusSuccess'), color: '#4ade80', pulse: false };
+    if (semanticBackgroundState === 'error') return { label: tr('statusError'), color: '#f87171', pulse: false };
+    if (semanticBackgroundState === 'warning') return { label: tr('statusWarning'), color: '#fb923c', pulse: false };
+    if (resolvedConnectionId && isConnectionReady) return { label: tr('statusConnected'), color: connectionColor, pulse: false };
+    return null;
+  }, [semanticBackgroundState, isConnectionReady, resolvedConnectionId, connectionColor, locale]);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<QueryErrorPresentation | null>(null);
@@ -244,6 +258,10 @@ export default function QueryWorkspace() {
       window.removeEventListener('keydown', handleEscape);
     };
   }, [connectionMenuOpen]);
+
+  const handleFormat = useCallback(() => {
+    editorRef.current?.getAction('editor.action.formatDocument')?.run();
+  }, []);
 
   const scheduleSemanticReset = useCallback((durationMs: number) => {
     if (semanticResetTimeoutRef.current) {
@@ -1289,7 +1307,45 @@ export default function QueryWorkspace() {
                 <Clock3 size={13} />
                 {t('history')}
               </button>
+              <button
+                onClick={handleFormat}
+                disabled={!activeTab}
+                className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{
+                  background: 'var(--bt-surface)',
+                  border: '1px solid var(--bt-border)',
+                  color: 'var(--bt-muted)',
+                }}
+              >
+                <AlignLeft size={13} />
+                {t('format')}
+              </button>
+              <button
+                disabled
+                title={t('explainComingSoon')}
+                className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium opacity-40 cursor-not-allowed"
+                style={{
+                  background: 'var(--bt-surface)',
+                  border: '1px solid var(--bt-border)',
+                  color: 'var(--bt-muted)',
+                }}
+              >
+                <Sparkles size={13} />
+                {t('explain')}
+              </button>
               <div className="ml-auto flex min-w-0 w-full sm:w-auto items-center gap-2">
+                {toolbarStatus ? (
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] transition-colors${toolbarStatus.pulse ? ' animate-pulse' : ''}`}
+                    style={{
+                      borderColor: hexToRgba(toolbarStatus.color, 0.35),
+                      background: hexToRgba(toolbarStatus.color, 0.10),
+                      color: toolbarStatus.color,
+                    }}
+                  >
+                    {toolbarStatus.label}
+                  </span>
+                ) : null}
                 <button
                   ref={connectionMenuButtonRef}
                   type="button"
@@ -1337,6 +1393,19 @@ export default function QueryWorkspace() {
                   onChange={(val) => updateTabContent(activeTab.id, val || "")}
                   beforeMount={(monaco) => {
                     ensureMonacoThemes(monaco);
+                    if (!sqlFormatterRegistered) {
+                      monaco.languages.registerDocumentFormattingEditProvider('sql', {
+                        provideDocumentFormattingEdits(model: import('monaco-editor').editor.ITextModel) {
+                          try {
+                            const formatted = sqlFormat(model.getValue(), { language: 'sql', tabWidth: 2 });
+                            return [{ range: model.getFullModelRange(), text: formatted }];
+                          } catch {
+                            return [];
+                          }
+                        },
+                      });
+                      sqlFormatterRegistered = true;
+                    }
                   }}
                   options={{
                     minimap: { enabled: false },
@@ -1367,6 +1436,20 @@ export default function QueryWorkspace() {
                   }}
                   onMount={(editor, monaco) => {
                     editorRef.current = editor;
+                    // Tauri WKWebView blocks navigator.clipboard.readText(); intercept native paste events directly
+                    const domNode = editor.getDomNode();
+                    if (domNode) {
+                      domNode.addEventListener('paste', (e: ClipboardEvent) => {
+                        const text = e.clipboardData?.getData('text/plain');
+                        if (!text) return;
+                        e.stopPropagation();
+                        e.preventDefault();
+                        const sel = editor.getSelection();
+                        const model = editor.getModel();
+                        if (!model) return;
+                        editor.executeEdits('paste', [{ range: sel ?? model.getFullModelRange(), text, forceMoveMarkers: true }]);
+                      }, true);
+                    }
                     autocompleteDisposableRef.current?.dispose();
                     autocompleteDisposableRef.current = registerSqlAutocomplete(monaco, () => autocompleteContextRef.current);
                     lastCursorPositionRef.current = editor.getPosition();

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { format as sqlFormat } from 'sql-formatter';
+import { readText as clipboardReadText } from '@tauri-apps/plugin-clipboard-manager';
 import { useQueriesStore } from '../../store/queries';
 import { type DatabaseEngine, useConnectionsStore, getConnectionColor, hexToRgba } from '../../store/connections';
 import { invoke } from '@tauri-apps/api/core';
@@ -1436,24 +1437,22 @@ export default function QueryWorkspace() {
                   }}
                   onMount={(editor, monaco) => {
                     editorRef.current = editor;
-                    // Tauri WKWebView: navigator.clipboard.readText() fails outside user-gesture context.
-                    // Override Cmd+V with a sync execCommand approach via a temp textarea.
-                    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
-                      const sel = editor.getSelection();
-                      const model = editor.getModel();
-                      if (!sel || !model) return;
-                      const ta = document.createElement('textarea');
-                      ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;';
-                      document.body.appendChild(ta);
-                      ta.focus();
-                      document.execCommand('paste');
-                      const text = ta.value;
-                      ta.remove();
-                      editor.focus();
-                      if (!text) return;
-                      editor.pushUndoStop();
-                      editor.executeEdits('paste', [{ range: sel, text, forceMoveMarkers: true }]);
-                      editor.pushUndoStop();
+                    // Tauri WKWebView blocks navigator.clipboard; intercept Cmd+V via onKeyDown
+                    // and read clipboard through the official Tauri plugin.
+                    editor.onKeyDown((e) => {
+                      if (e.keyCode === monaco.KeyCode.KeyV && (e.ctrlKey || e.metaKey)) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const sel = editor.getSelection();
+                        const model = editor.getModel();
+                        if (!sel || !model) return;
+                        void clipboardReadText().then((text) => {
+                          if (!text) return;
+                          editor.pushUndoStop();
+                          editor.executeEdits('paste', [{ range: sel, text, forceMoveMarkers: true }]);
+                          editor.pushUndoStop();
+                        });
+                      }
                     });
                     autocompleteDisposableRef.current?.dispose();
                     autocompleteDisposableRef.current = registerSqlAutocomplete(monaco, () => autocompleteContextRef.current);

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -245,7 +245,14 @@ const messages = {
     importConnections: 'Importar conexoes',
     exportConnections: 'Exportar conexoes',
     importConnectionsError: 'Falha ao importar: {message}',
-    importConnectionsSuccess: '{count} conexao(oes) importada(s).'
+    importConnectionsSuccess: '{count} conexao(oes) importada(s).',
+    format: 'Formatar',
+    explain: 'Explicar',
+    explainComingSoon: 'Em breve · requer IA',
+    statusRunning: 'EM EXECUCAO',
+    statusSuccess: 'SUCESSO',
+    statusError: 'ERRO',
+    statusWarning: 'AVISO',
   },
   'en-US': {
     language: 'Language',
@@ -481,7 +488,14 @@ const messages = {
     importConnections: 'Import connections',
     exportConnections: 'Export connections',
     importConnectionsError: 'Import failed: {message}',
-    importConnectionsSuccess: '{count} connection(s) imported.'
+    importConnectionsSuccess: '{count} connection(s) imported.',
+    format: 'Format',
+    explain: 'Explain',
+    explainComingSoon: 'Coming soon · requires AI',
+    statusRunning: 'RUNNING',
+    statusSuccess: 'SUCCESS',
+    statusError: 'ERROR',
+    statusWarning: 'WARNING',
   }
 } as const;
 

--- a/src/store/connections.ts
+++ b/src/store/connections.ts
@@ -33,6 +33,7 @@ export interface ConnectionConfig {
   oracleDriverProperties?: string;
   preferredSchema?: string;
   ssh?: SshConfig;
+  color?: string;
 }
 
 export const CONNECTION_COLOR_PALETTE = [
@@ -48,8 +49,11 @@ export const CONNECTION_COLOR_PALETTE = [
 
 export function getConnectionColor(connections: ConnectionConfig[], connId: string | null | undefined): string {
   if (!connId) return '#47C4E8';
+  const conn = connections.find((c) => c.id === connId);
+  if (!conn) return '#47C4E8';
+  if (conn.color) return conn.color;
   const idx = connections.findIndex((c) => c.id === connId);
-  return idx === -1 ? '#47C4E8' : CONNECTION_COLOR_PALETTE[idx % CONNECTION_COLOR_PALETTE.length];
+  return CONNECTION_COLOR_PALETTE[idx % CONNECTION_COLOR_PALETTE.length];
 }
 
 export function hexToRgba(hex: string, alpha: number): string {
@@ -237,6 +241,7 @@ function normalizeConnection(input: unknown): ConnectionConfig | null {
     oracleConnectionType: raw.oracleConnectionType === 'sid' ? 'sid' : 'serviceName',
     oracleDriverProperties: asOptionalString(raw.oracleDriverProperties),
     preferredSchema: asOptionalString(raw.preferredSchema),
+    color: asOptionalString(raw.color),
     ssh: {
       enabled: sshEnabled,
       host: asOptionalString(ssh?.host ?? raw.sshHost),


### PR DESCRIPTION
## Summary

- **Bloco 0 — Color picker por conexão**: badge PG/ORA/MY clicável abre popover de cor; palette + input nativo no ConnectionForm; "Change color…" no right-click menu; backdrop para fechar ao clicar fora
- **Bloco 1 — Toolbar**: botões Format (sql-formatter via Monaco) e Explain (inativo, tooltip); status badge dinâmico (CONNECTED/RUNNING/SUCCESS/ERROR/WARNING) com cor da conexão
- **Fix paste**: intercepta evento `paste` nativo no Monaco (capture phase) para contornar bloqueio do `navigator.clipboard.readText()` no Tauri WKWebView

## Test plan

- [ ] Criar conexão e verificar que a cor selecionada persiste no badge e na UI
- [ ] Clicar no badge PG/ORA/MY e trocar a cor via popover e palette
- [ ] "Change color…" no right-click abre o popover
- [ ] Colar texto (Cmd+V) no editor SQL funciona
- [ ] Botão Format formata o SQL no editor
- [ ] Botão Explain aparece desabilitado com tooltip "Coming soon · requires AI"
- [ ] Status badge muda corretamente: CONNECTED → RUNNING → SUCCESS/ERROR após executar query