### PR TITLE
chore: bump version to 0.2.0-2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.2.0-1",
+  "version": "0.2.0-2",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps version to 0.2.0-2 after merging ATLAS Bloco 2 (PR #87).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)