### PR TITLE
chore: bump version to 0.2.0-4

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,7 +155,7 @@ fn create_splash_window(app: &AppHandle) -> Result<(), String> {
         WebviewUrl::App("splash.html".into()),
     )
         .title("PulseSQL")
-        .inner_size(490.0, 420.0)
+        .inner_size(490.0, 480.0)
         .resizable(false)
         .maximizable(false)
         .minimizable(false)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PulseSQL",
-  "version": "0.2.0-3",
+  "version": "0.2.0-4",
   "identifier": "com.pulsesql.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/SplashScreen.tsx
+++ b/src/SplashScreen.tsx
@@ -5,7 +5,6 @@ import { getInitialLocale, translate } from './i18n';
 import { LOCK_SPLASH_FOR_DEV } from './devFlags';
 import EcgMonitor from './components/ui/EcgMonitor';
 import { useConnectionsStore, getConnectionColor, hexToRgba } from './store/connections';
-import tauriConfig from '../src-tauri/tauri.conf.json';
 
 const MIN_SPLASH_MS = 5000;
 
@@ -129,16 +128,13 @@ export default function SplashScreen() {
         '--splash-glow':    hexToRgba(ecgColor, 0.18),
       } as React.CSSProperties}
     >
-      <div ref={monitorRef} style={{ width: '100%', height: 64, borderRadius: 8, background: '#010a0e', overflow: 'hidden', marginBottom: 24 }}>
-        <EcgMonitor color={ecgColor} width={monitorWidth} height={64} speed={finishing ? 0.0025 : 0.004} />
+      <div ref={monitorRef} style={{ width: '100%', height: 160, overflow: 'hidden' }}>
+        <EcgMonitor color={ecgColor} width={monitorWidth} height={160} speed={finishing ? 0.0025 : 0.004} transparent />
       </div>
 
       <div className="splash-screen__copy">
         <div className="splash-screen__title">PulseSQL</div>
         <div className="splash-screen__subtitle">{translate(locale, 'aboutSubtitle')}</div>
-        <div style={{ fontSize: 10, fontFamily: 'monospace', color: 'var(--bt-muted)', letterSpacing: '0.8px', marginTop: 4 }}>
-          v{tauriConfig.version}
-        </div>
       </div>
 
       <div className="splash-screen__progress">

--- a/src/index.css
+++ b/src/index.css
@@ -640,15 +640,14 @@ body[data-density='compact'] .bt-density-chip {
   position: relative;
   z-index: 1;
   display: flex;
-  width: 300px;
+  width: 450px;
   max-width: calc(100vw - 24px);
   flex-direction: column;
-  gap: 14px;
+  gap: 24px;
   border: 1px solid rgba(var(--bt-border-rgb), 0.78);
-  border-radius: 12px;
-  padding: 20px 20px 16px;
-  background:
-    linear-gradient(180deg, rgba(var(--bt-surface-rgb), 0.96), rgba(var(--bt-background-rgb), 0.98));
+  border-radius: 16px;
+  padding: 36px 28px 32px;
+  background: var(--bt-background);
   box-shadow:
     0 24px 54px rgba(0, 0, 0, 0.36),
     inset 0 1px 0 rgba(255, 255, 255, 0.035);
@@ -691,16 +690,16 @@ body[data-density='compact'] .bt-density-chip {
 }
 
 .splash-screen__title {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
   color: var(--bt-text);
   line-height: 1.1;
 }
 
 .splash-screen__subtitle {
   font-size: 10px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(var(--bt-muted-rgb), 0.72);
 }


### PR DESCRIPTION
## Summary

- Splash screen polished: square card (490×480), ECG transparent (no dark background), solid `#08111a` card background, ECG monitor 160px tall, version number removed, larger padding/gap

🤖 Generated with [Claude Code](https://claude.ai/claude-code)