### PR TITLE
feat: SQL performance improvements and professional result grid

### DIFF
--- a/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
+++ b/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
@@ -237,13 +237,14 @@ public class OracleJdbcRunner {
         List<String> lastColumns = new ArrayList<>();
         List<String> lastRows = new ArrayList<>();
         List<String> lastColumnMeta = new ArrayList<>();
+        List<String> diagnostics = new ArrayList<>();
         Long totalRows = null;
         Integer page = null;
         Integer pageSize = null;
 
         for (String statementSql : statements) {
           if (isPaginableResultQuery(statementSql)) {
-            SelectResult selectResult = readPagedSelectResult(connection, statementSql, request);
+            SelectResult selectResult = readPagedSelectResult(connection, statementSql, request, diagnostics);
             lastColumns = selectResult.columns;
             lastColumnMeta = selectResult.columnMeta;
             lastRows = selectResult.rows;
@@ -259,7 +260,9 @@ public class OracleJdbcRunner {
 
             if (hasResultSet) {
               try (ResultSet resultSet = statement.getResultSet()) {
+                long serializeStarted = System.currentTimeMillis();
                 SelectResult selectResult = readResultSet(resultSet, null, null, null);
+                diagnostics.add("[oracle] serialize_ms: " + (System.currentTimeMillis() - serializeStarted));
                 lastColumns = selectResult.columns;
                 lastColumnMeta = selectResult.columnMeta;
                 lastRows = selectResult.rows;
@@ -287,7 +290,8 @@ public class OracleJdbcRunner {
             System.currentTimeMillis() - startedAt,
             totalRows,
             page,
-            pageSize
+            pageSize,
+            diagnostics
         );
       } catch (Exception error) {
         connection.rollback();
@@ -296,14 +300,17 @@ public class OracleJdbcRunner {
     }
   }
 
-  private static SelectResult readPagedSelectResult(Connection connection, String statementSql, Request request) throws Exception {
+  private static SelectResult readPagedSelectResult(Connection connection, String statementSql, Request request, List<String> diagnostics) throws Exception {
+    long prepareStarted = System.currentTimeMillis();
     int normalizedPage = Math.max(1, request.page == null ? 1 : request.page);
     int normalizedPageSize = Math.max(1, Math.min(1000, request.pageSize == null ? 100 : request.pageSize));
     long offset = (long) (normalizedPage - 1) * normalizedPageSize;
     String pagedSql = "SELECT * FROM (" + statementSql + ") blacktable_page OFFSET " + offset + " ROWS FETCH NEXT " + normalizedPageSize + " ROWS ONLY";
     String countSql = "SELECT COUNT(*) AS blacktable_total FROM (" + statementSql + ") blacktable_count";
+    diagnostics.add("[oracle] prepare_ms: " + (System.currentTimeMillis() - prepareStarted));
 
     long totalRows;
+    long countStarted = System.currentTimeMillis();
     try (Statement countStatement = connection.createStatement()) {
       countStatement.setQueryTimeout(30);
       try (ResultSet countResult = countStatement.executeQuery(countSql)) {
@@ -311,11 +318,18 @@ public class OracleJdbcRunner {
         totalRows = countResult.getLong(1);
       }
     }
+    diagnostics.add("[oracle] count_ms: " + (System.currentTimeMillis() - countStarted));
 
+    long dataStarted = System.currentTimeMillis();
     try (Statement pageStatement = connection.createStatement()) {
       pageStatement.setQueryTimeout(30);
       try (ResultSet pageResult = pageStatement.executeQuery(pagedSql)) {
-        return readResultSet(pageResult, totalRows, normalizedPage, normalizedPageSize);
+        long serializeStarted = System.currentTimeMillis();
+        SelectResult result = readResultSet(pageResult, totalRows, normalizedPage, normalizedPageSize);
+        diagnostics.add("[oracle] serialize_ms: " + (System.currentTimeMillis() - serializeStarted));
+        diagnostics.add("[oracle] data_ms: " + (System.currentTimeMillis() - dataStarted));
+        diagnostics.add("[oracle] rows_returned: " + result.rows.size());
+        return result;
       }
     }
   }
@@ -357,7 +371,7 @@ public class OracleJdbcRunner {
     return new SelectResult(columns, columnMeta, rows, totalRows, page, pageSize);
   }
 
-  private static String buildExecuteResponseJson(List<String> columns, List<String> columnMeta, List<String> rows, String summary, long executionTime, Long totalRows, Integer page, Integer pageSize) {
+  private static String buildExecuteResponseJson(List<String> columns, List<String> columnMeta, List<String> rows, String summary, long executionTime, Long totalRows, Integer page, Integer pageSize, List<String> diagnostics) {
     StringBuilder json = new StringBuilder();
     json.append("{\"columns\":");
     appendJsonStringArray(json, columns);
@@ -386,6 +400,11 @@ public class OracleJdbcRunner {
         .append(page == null ? "null" : page)
         .append(",\"page_size\":")
         .append(pageSize == null ? "null" : pageSize)
+        .append(",\"has_more\":")
+        .append(hasMore(totalRows, page, pageSize))
+        .append(",\"diagnostics\":");
+    appendJsonStringArray(json, diagnostics);
+    json
         .append('}');
     return json.toString();
   }
@@ -399,6 +418,14 @@ public class OracleJdbcRunner {
       json.append(quote(items.get(index)));
     }
     json.append(']');
+  }
+
+  private static String hasMore(Long totalRows, Integer page, Integer pageSize) {
+    if (totalRows == null || page == null || pageSize == null) {
+      return "null";
+    }
+
+    return String.valueOf((long) page * (long) pageSize < totalRows);
   }
 
   private static String buildStatementSummary(String sql, int updateCount) {

--- a/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
+++ b/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
@@ -15,11 +15,15 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 
 public class OracleJdbcRunner {
+  private static final Map<String, Connection> CONNECTIONS = new HashMap<>();
+
   public static void main(String[] args) throws Exception {
     // Persistent server mode: read JSON requests from stdin, write responses to stdout.
     // Invoked as: java OracleJdbcRunner --server
@@ -47,8 +51,12 @@ public class OracleJdbcRunner {
           writeSuccess(responsePath, "{\"message\":\"Connection successful\"}");
           break;
         case "open":
-          testConnection(request);
+          openPersistentConnection(request);
           writeSuccess(responsePath, "{\"message\":\"Connection opened\"}");
+          break;
+        case "close":
+          closePersistentConnection(request);
+          writeSuccess(responsePath, "{\"message\":\"Connection closed\"}");
           break;
         case "listDatabases":
           writeSuccess(responsePath, listItems(request, "SELECT SYS_CONTEXT('USERENV', 'DB_NAME') AS DB_NAME FROM dual"));
@@ -104,8 +112,12 @@ public class OracleJdbcRunner {
             response = "{\"message\":\"Connection successful\"}";
             break;
           case "open":
-            testConnection(request);
+            openPersistentConnection(request);
             response = "{\"message\":\"Connection opened\"}";
+            break;
+          case "close":
+            closePersistentConnection(request);
+            response = "{\"message\":\"Connection closed\"}";
             break;
           case "listDatabases":
             response = listItems(request, "SELECT SYS_CONTEXT('USERENV', 'DB_NAME') AS DB_NAME FROM dual");
@@ -159,9 +171,67 @@ public class OracleJdbcRunner {
     }
   }
 
+  private static void openPersistentConnection(Request request) throws Exception {
+    Connection connection = getPersistentConnection(request);
+    if (!connection.isValid(10)) {
+      throw new IllegalStateException("Oracle connection validation failed.");
+    }
+  }
+
+  private static void closePersistentConnection(Request request) throws Exception {
+    String key = connectionKey(request);
+    Connection connection = CONNECTIONS.remove(key);
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  private static Connection getPersistentConnection(Request request) throws Exception {
+    Class.forName("oracle.jdbc.OracleDriver");
+    String key = connectionKey(request);
+    Connection existing = CONNECTIONS.get(key);
+
+    if (isConnectionUsable(existing)) {
+      return existing;
+    }
+
+    if (existing != null) {
+      try {
+        existing.close();
+      } catch (Exception ignored) {
+      }
+      CONNECTIONS.remove(key);
+    }
+
+    DriverManager.setLoginTimeout((int) Duration.ofSeconds(10).toSeconds());
+    Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
+    if (!connection.isValid(10)) {
+      connection.close();
+      throw new IllegalStateException("Oracle connection validation failed.");
+    }
+
+    CONNECTIONS.put(key, connection);
+    return connection;
+  }
+
+  private static boolean isConnectionUsable(Connection connection) {
+    try {
+      return connection != null && !connection.isClosed() && connection.isValid(2);
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  private static String connectionKey(Request request) {
+    return request.jdbcUrl()
+        + "|user=" + request.user
+        + "|password=" + request.password
+        + "|props=" + (request.oracleDriverProperties == null ? "" : request.oracleDriverProperties);
+  }
+
   private static String listItems(Request request, String sql) throws Exception {
-    try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
-         Statement statement = connection.createStatement();
+    Connection connection = getPersistentConnection(request);
+    try (Statement statement = connection.createStatement();
          ResultSet resultSet = statement.executeQuery(sql)) {
       List<String> items = new ArrayList<>();
 
@@ -193,8 +263,8 @@ public class OracleJdbcRunner {
         " ) fk ON fk.column_name = c.column_name" +
         " WHERE c.owner = '" + schemaEsc + "' AND c.table_name = '" + tableEsc + "' ORDER BY c.column_id";
 
-    try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
-         Statement statement = connection.createStatement();
+    Connection connection = getPersistentConnection(request);
+    try (Statement statement = connection.createStatement();
          ResultSet resultSet = statement.executeQuery(sql)) {
       StringBuilder json = new StringBuilder();
       json.append("{\"column_defs\":[");
@@ -235,77 +305,81 @@ public class OracleJdbcRunner {
       throw new IllegalArgumentException("Nenhum comando SQL informado.");
     }
 
-    try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties())) {
-      connection.setAutoCommit(false);
+    Connection connection = getPersistentConnection(request);
+    connection.setAutoCommit(false);
 
-      try {
-        List<String> summaryParts = new ArrayList<>();
-        List<String> lastColumns = new ArrayList<>();
-        List<String> lastRows = new ArrayList<>();
-        List<String> lastColumnMeta = new ArrayList<>();
-        List<String> diagnostics = new ArrayList<>();
-        Long totalRows = null;
-        Integer page = null;
-        Integer pageSize = null;
-        Boolean hasMore = null;
+    try {
+      List<String> summaryParts = new ArrayList<>();
+      List<String> lastColumns = new ArrayList<>();
+      List<String> lastRows = new ArrayList<>();
+      List<String> lastColumnMeta = new ArrayList<>();
+      List<String> diagnostics = new ArrayList<>();
+      Long totalRows = null;
+      Integer page = null;
+      Integer pageSize = null;
+      Boolean hasMore = null;
 
-        for (String statementSql : statements) {
-          if (isPaginableResultQuery(statementSql)) {
-            SelectResult selectResult = readPagedSelectResult(connection, statementSql, request, diagnostics);
-            lastColumns = selectResult.columns;
-            lastColumnMeta = selectResult.columnMeta;
-            lastRows = selectResult.rows;
-            totalRows = selectResult.totalRows;
-            page = selectResult.page;
-            pageSize = selectResult.pageSize;
-            hasMore = selectResult.hasMore;
+      for (String statementSql : statements) {
+        if (isPaginableResultQuery(statementSql)) {
+          SelectResult selectResult = readPagedSelectResult(connection, statementSql, request, diagnostics);
+          lastColumns = selectResult.columns;
+          lastColumnMeta = selectResult.columnMeta;
+          lastRows = selectResult.rows;
+          totalRows = selectResult.totalRows;
+          page = selectResult.page;
+          pageSize = selectResult.pageSize;
+          hasMore = selectResult.hasMore;
+          continue;
+        }
+
+        try (Statement statement = connection.createStatement()) {
+          statement.setQueryTimeout(30);
+          boolean hasResultSet = statement.execute(statementSql);
+
+          if (hasResultSet) {
+            try (ResultSet resultSet = statement.getResultSet()) {
+              long serializeStarted = System.currentTimeMillis();
+              SelectResult selectResult = readResultSet(resultSet, null, null, null);
+              diagnostics.add("[oracle] serialize_ms: " + (System.currentTimeMillis() - serializeStarted));
+              lastColumns = selectResult.columns;
+              lastColumnMeta = selectResult.columnMeta;
+              lastRows = selectResult.rows;
+              totalRows = selectResult.totalRows;
+              page = selectResult.page;
+              pageSize = selectResult.pageSize;
+              hasMore = selectResult.hasMore;
+            }
             continue;
           }
 
-          try (Statement statement = connection.createStatement()) {
-            statement.setQueryTimeout(30);
-            boolean hasResultSet = statement.execute(statementSql);
-
-            if (hasResultSet) {
-              try (ResultSet resultSet = statement.getResultSet()) {
-                long serializeStarted = System.currentTimeMillis();
-                SelectResult selectResult = readResultSet(resultSet, null, null, null);
-                diagnostics.add("[oracle] serialize_ms: " + (System.currentTimeMillis() - serializeStarted));
-                lastColumns = selectResult.columns;
-                lastColumnMeta = selectResult.columnMeta;
-                lastRows = selectResult.rows;
-                totalRows = selectResult.totalRows;
-                page = selectResult.page;
-                pageSize = selectResult.pageSize;
-                hasMore = selectResult.hasMore;
-              }
-              continue;
-            }
-
-            String summary = buildStatementSummary(statementSql, statement.getUpdateCount());
-            if (summary != null) {
-              summaryParts.add(summary);
-            }
+          String summary = buildStatementSummary(statementSql, statement.getUpdateCount());
+          if (summary != null) {
+            summaryParts.add(summary);
           }
         }
+      }
 
-        connection.commit();
+      connection.commit();
 
-        return buildExecuteResponseJson(
-            lastColumns,
-            lastColumnMeta,
-            lastRows,
-            summaryParts.isEmpty() ? null : String.join("\n\n", summaryParts),
-            System.currentTimeMillis() - startedAt,
-            totalRows,
-            page,
-            pageSize,
-            hasMore,
-            diagnostics
-        );
-      } catch (Exception error) {
-        connection.rollback();
-        throw error;
+      return buildExecuteResponseJson(
+          lastColumns,
+          lastColumnMeta,
+          lastRows,
+          summaryParts.isEmpty() ? null : String.join("\n\n", summaryParts),
+          System.currentTimeMillis() - startedAt,
+          totalRows,
+          page,
+          pageSize,
+          hasMore,
+          diagnostics
+      );
+    } catch (Exception error) {
+      connection.rollback();
+      throw error;
+    } finally {
+      try {
+        connection.setAutoCommit(true);
+      } catch (Exception ignored) {
       }
     }
   }
@@ -320,8 +394,8 @@ public class OracleJdbcRunner {
 
     String countSql = "SELECT COUNT(*) AS blacktable_total FROM (" + statements.get(0) + ") blacktable_count";
 
-    try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
-         Statement statement = connection.createStatement()) {
+    Connection connection = getPersistentConnection(request);
+    try (Statement statement = connection.createStatement()) {
       statement.setQueryTimeout(30);
       long countStarted = System.currentTimeMillis();
       try (ResultSet resultSet = statement.executeQuery(countSql)) {

--- a/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
+++ b/src-tauri/oracle-jdbc-sidecar/OracleJdbcRunner.java
@@ -65,6 +65,9 @@ public class OracleJdbcRunner {
         case "executeQuery":
           writeSuccess(responsePath, executeQuery(request));
           break;
+        case "countQuery":
+          writeSuccess(responsePath, countQuery(request));
+          break;
         default:
           throw new IllegalArgumentException("Unsupported Oracle sidecar command: " + command);
       }
@@ -118,6 +121,9 @@ public class OracleJdbcRunner {
             break;
           case "executeQuery":
             response = executeQuery(request);
+            break;
+          case "countQuery":
+            response = countQuery(request);
             break;
           default:
             response = "{\"error\":" + quote("Unsupported Oracle sidecar command: " + command) + "}";
@@ -241,6 +247,7 @@ public class OracleJdbcRunner {
         Long totalRows = null;
         Integer page = null;
         Integer pageSize = null;
+        Boolean hasMore = null;
 
         for (String statementSql : statements) {
           if (isPaginableResultQuery(statementSql)) {
@@ -251,6 +258,7 @@ public class OracleJdbcRunner {
             totalRows = selectResult.totalRows;
             page = selectResult.page;
             pageSize = selectResult.pageSize;
+            hasMore = selectResult.hasMore;
             continue;
           }
 
@@ -269,6 +277,7 @@ public class OracleJdbcRunner {
                 totalRows = selectResult.totalRows;
                 page = selectResult.page;
                 pageSize = selectResult.pageSize;
+                hasMore = selectResult.hasMore;
               }
               continue;
             }
@@ -291,6 +300,7 @@ public class OracleJdbcRunner {
             totalRows,
             page,
             pageSize,
+            hasMore,
             diagnostics
         );
       } catch (Exception error) {
@@ -300,25 +310,42 @@ public class OracleJdbcRunner {
     }
   }
 
+  private static String countQuery(Request request) throws Exception {
+    long startedAt = System.currentTimeMillis();
+    List<String> statements = splitExecutableStatements(request.query);
+
+    if (statements.size() != 1 || !isPaginableResultQuery(statements.get(0))) {
+      throw new IllegalArgumentException("Only one SELECT/WITH query can be counted.");
+    }
+
+    String countSql = "SELECT COUNT(*) AS blacktable_total FROM (" + statements.get(0) + ") blacktable_count";
+
+    try (Connection connection = DriverManager.getConnection(request.jdbcUrl(), request.properties());
+         Statement statement = connection.createStatement()) {
+      statement.setQueryTimeout(30);
+      long countStarted = System.currentTimeMillis();
+      try (ResultSet resultSet = statement.executeQuery(countSql)) {
+        resultSet.next();
+        long totalRows = Math.max(0, resultSet.getLong(1));
+        List<String> diagnostics = new ArrayList<>();
+        diagnostics.add("[oracle] count_ms: " + (System.currentTimeMillis() - countStarted));
+        diagnostics.add("[oracle] count_total_ms: " + (System.currentTimeMillis() - startedAt));
+        return buildCountResponseJson(totalRows, System.currentTimeMillis() - startedAt, diagnostics);
+      }
+    }
+  }
+
   private static SelectResult readPagedSelectResult(Connection connection, String statementSql, Request request, List<String> diagnostics) throws Exception {
     long prepareStarted = System.currentTimeMillis();
     int normalizedPage = Math.max(1, request.page == null ? 1 : request.page);
     int normalizedPageSize = Math.max(1, Math.min(1000, request.pageSize == null ? 100 : request.pageSize));
+    int fetchPageSize = normalizedPageSize + 1;
     long offset = (long) (normalizedPage - 1) * normalizedPageSize;
-    String pagedSql = "SELECT * FROM (" + statementSql + ") blacktable_page OFFSET " + offset + " ROWS FETCH NEXT " + normalizedPageSize + " ROWS ONLY";
-    String countSql = "SELECT COUNT(*) AS blacktable_total FROM (" + statementSql + ") blacktable_count";
+    String pagedSql = "SELECT * FROM (" + statementSql + ") blacktable_page OFFSET " + offset + " ROWS FETCH NEXT " + fetchPageSize + " ROWS ONLY";
     diagnostics.add("[oracle] prepare_ms: " + (System.currentTimeMillis() - prepareStarted));
 
-    long totalRows;
-    long countStarted = System.currentTimeMillis();
-    try (Statement countStatement = connection.createStatement()) {
-      countStatement.setQueryTimeout(30);
-      try (ResultSet countResult = countStatement.executeQuery(countSql)) {
-        countResult.next();
-        totalRows = countResult.getLong(1);
-      }
-    }
-    diagnostics.add("[oracle] count_ms: " + (System.currentTimeMillis() - countStarted));
+    Long totalRows = request.knownTotalRows;
+    diagnostics.add("[oracle] count_ms: 0");
 
     long dataStarted = System.currentTimeMillis();
     try (Statement pageStatement = connection.createStatement()) {
@@ -326,6 +353,17 @@ public class OracleJdbcRunner {
       try (ResultSet pageResult = pageStatement.executeQuery(pagedSql)) {
         long serializeStarted = System.currentTimeMillis();
         SelectResult result = readResultSet(pageResult, totalRows, normalizedPage, normalizedPageSize);
+        boolean dataHasMore = result.rows.size() > normalizedPageSize;
+        trimRows(result.rows, normalizedPageSize);
+        result = new SelectResult(
+            result.columns,
+            result.columnMeta,
+            result.rows,
+            result.totalRows,
+            result.page,
+            result.pageSize,
+            dataHasMore || hasMoreFromTotal(totalRows, normalizedPage, normalizedPageSize)
+        );
         diagnostics.add("[oracle] serialize_ms: " + (System.currentTimeMillis() - serializeStarted));
         diagnostics.add("[oracle] data_ms: " + (System.currentTimeMillis() - dataStarted));
         diagnostics.add("[oracle] rows_returned: " + result.rows.size());
@@ -368,10 +406,10 @@ public class OracleJdbcRunner {
       rows.add(rowJson.toString());
     }
 
-    return new SelectResult(columns, columnMeta, rows, totalRows, page, pageSize);
+    return new SelectResult(columns, columnMeta, rows, totalRows, page, pageSize, null);
   }
 
-  private static String buildExecuteResponseJson(List<String> columns, List<String> columnMeta, List<String> rows, String summary, long executionTime, Long totalRows, Integer page, Integer pageSize, List<String> diagnostics) {
+  private static String buildExecuteResponseJson(List<String> columns, List<String> columnMeta, List<String> rows, String summary, long executionTime, Long totalRows, Integer page, Integer pageSize, Boolean hasMore, List<String> diagnostics) {
     StringBuilder json = new StringBuilder();
     json.append("{\"columns\":");
     appendJsonStringArray(json, columns);
@@ -401,11 +439,23 @@ public class OracleJdbcRunner {
         .append(",\"page_size\":")
         .append(pageSize == null ? "null" : pageSize)
         .append(",\"has_more\":")
-        .append(hasMore(totalRows, page, pageSize))
+        .append(hasMore(hasMore, totalRows, page, pageSize))
         .append(",\"diagnostics\":");
     appendJsonStringArray(json, diagnostics);
     json
         .append('}');
+    return json.toString();
+  }
+
+  private static String buildCountResponseJson(long totalRows, long executionTime, List<String> diagnostics) {
+    StringBuilder json = new StringBuilder();
+    json.append("{\"total_rows\":")
+        .append(totalRows)
+        .append(",\"execution_time\":")
+        .append(executionTime)
+        .append(",\"diagnostics\":");
+    appendJsonStringArray(json, diagnostics);
+    json.append('}');
     return json.toString();
   }
 
@@ -420,12 +470,26 @@ public class OracleJdbcRunner {
     json.append(']');
   }
 
-  private static String hasMore(Long totalRows, Integer page, Integer pageSize) {
+  private static void trimRows(List<String> rows, int pageSize) {
+    while (rows.size() > pageSize) {
+      rows.remove(rows.size() - 1);
+    }
+  }
+
+  private static String hasMore(Boolean dataHasMore, Long totalRows, Integer page, Integer pageSize) {
+    if (dataHasMore != null && dataHasMore) {
+      return "true";
+    }
+
     if (totalRows == null || page == null || pageSize == null) {
-      return "null";
+      return dataHasMore == null ? "null" : String.valueOf(dataHasMore);
     }
 
     return String.valueOf((long) page * (long) pageSize < totalRows);
+  }
+
+  private static boolean hasMoreFromTotal(Long totalRows, Integer page, Integer pageSize) {
+    return totalRows != null && page != null && pageSize != null && (long) page * (long) pageSize < totalRows;
   }
 
   private static String buildStatementSummary(String sql, int updateCount) {
@@ -765,14 +829,16 @@ public class OracleJdbcRunner {
     final Long totalRows;
     final Integer page;
     final Integer pageSize;
+    final Boolean hasMore;
 
-    SelectResult(List<String> columns, List<String> columnMeta, List<String> rows, Long totalRows, Integer page, Integer pageSize) {
+    SelectResult(List<String> columns, List<String> columnMeta, List<String> rows, Long totalRows, Integer page, Integer pageSize, Boolean hasMore) {
       this.columns = columns;
       this.columnMeta = columnMeta;
       this.rows = rows;
       this.totalRows = totalRows;
       this.page = page;
       this.pageSize = pageSize;
+      this.hasMore = hasMore;
     }
   }
 
@@ -1010,10 +1076,11 @@ public class OracleJdbcRunner {
     final String query;
     final Integer page;
     final Integer pageSize;
+    final Long knownTotalRows;
     final String schema;
     final String table;
 
-    Request(String host, int port, String database, String oracleConnectionType, String user, String password, String oracleDriverProperties, String query, Integer page, Integer pageSize, String schema, String table) {
+    Request(String host, int port, String database, String oracleConnectionType, String user, String password, String oracleDriverProperties, String query, Integer page, Integer pageSize, Long knownTotalRows, String schema, String table) {
       this.host = host;
       this.port = port;
       this.database = database;
@@ -1024,6 +1091,7 @@ public class OracleJdbcRunner {
       this.query = query;
       this.page = page;
       this.pageSize = pageSize;
+      this.knownTotalRows = knownTotalRows;
       this.schema = schema;
       this.table = table;
     }
@@ -1081,6 +1149,7 @@ public class OracleJdbcRunner {
           extractNullableString(json, "query"),
           extractNullableNumber(json, "page"),
           extractNullableNumber(json, "page_size"),
+          extractNullableLong(json, "known_total_rows"),
           extractNullableString(json, "schema"),
           extractNullableString(json, "table")
       );
@@ -1181,6 +1250,34 @@ public class OracleJdbcRunner {
       }
 
       return Integer.parseInt(json.substring(valueStart, valueEnd));
+    }
+
+    private static Long extractNullableLong(String json, String field) {
+      String needle = "\"" + field + "\":";
+      int start = json.indexOf(needle);
+      if (start < 0) {
+        return null;
+      }
+
+      int valueStart = start + needle.length();
+      while (valueStart < json.length() && Character.isWhitespace(json.charAt(valueStart))) {
+        valueStart++;
+      }
+
+      if (json.startsWith("null", valueStart)) {
+        return null;
+      }
+
+      int valueEnd = valueStart;
+      while (valueEnd < json.length() && Character.isDigit(json.charAt(valueEnd))) {
+        valueEnd++;
+      }
+
+      if (valueEnd == valueStart) {
+        throw new IllegalArgumentException("Invalid numeric field " + field);
+      }
+
+      return Long.parseLong(json.substring(valueStart, valueEnd));
     }
   }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -37,6 +37,10 @@ pub struct QueryResult {
     pub total_rows: Option<u64>,
     pub page: Option<u32>,
     pub page_size: Option<u32>,
+    #[serde(default)]
+    pub has_more: Option<bool>,
+    #[serde(default, skip_serializing)]
+    pub diagnostics: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -340,8 +344,31 @@ pub fn execute_query(
                 let row_count =
                     i64::try_from(result.result.total_rows.unwrap_or(result.result.rows.len() as u64))
                         .unwrap_or(i64::MAX);
+                let result_payload_bytes = serde_json::to_vec(&result.result)
+                    .map(|payload| payload.len())
+                    .unwrap_or_default();
+                let mut diagnostics = result.result.diagnostics.clone();
+                diagnostics.extend([
+                    format!("[db] resolve_connection_details: {resolve_ms}ms"),
+                    format!("[db] execute_query_on_managed_connection: {execute_ms}ms"),
+                    format!("[db] result rows_returned: {}", result.result.rows.len()),
+                    format!(
+                        "[db] result page: {}",
+                        result.result.page.map_or_else(|| "none".into(), |value| value.to_string())
+                    ),
+                    format!(
+                        "[db] result page_size: {}",
+                        result
+                            .result
+                            .page_size
+                            .map_or_else(|| "none".into(), |value| value.to_string())
+                    ),
+                    format!("[db] result payload_bytes: {result_payload_bytes}"),
+                    format!("[db] total execute_query command: {}ms", t_total.elapsed().as_millis()),
+                ]);
 
                 // Fire-and-forget: history write does not block the response to the frontend.
+                let history_started = Instant::now();
                 history.record_spawned(NewQueryHistoryItem {
                     id: history_item_id.clone(),
                     connection_id: conn_id,
@@ -357,17 +384,17 @@ pub fn execute_query(
                     error_message: None,
                     row_count: Some(row_count),
                 });
+                diagnostics.push(format!(
+                    "[db] history_enqueue_ms: {}",
+                    history_started.elapsed().as_millis()
+                ));
 
                 let payload = ExecuteQueryPayload {
                     result: result.result,
                     history_item_id,
                     autocommit_enabled: result.autocommit_enabled,
                     transaction_open: result.transaction_open,
-                    diagnostics: vec![
-                        format!("[db] resolve_connection_details: {resolve_ms}ms"),
-                        format!("[db] execute_query_on_managed_connection: {execute_ms}ms"),
-                        format!("[db] total execute_query command: {}ms", t_total.elapsed().as_millis()),
-                    ],
+                    diagnostics,
                 };
                 Ok(payload)
             }
@@ -754,5 +781,7 @@ fn build_transaction_summary_result(summary: &str) -> QueryResult {
         total_rows: None,
         page: None,
         page_size: None,
+        has_more: None,
+        diagnostics: Vec::new(),
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -70,7 +70,9 @@ impl ManagedConnection {
         match self.pool {
             ConnectionPool::Postgres(pool) => pool.close().await,
             ConnectionPool::Mysql(pool) => pool.close().await,
-            ConnectionPool::Oracle(_) => {}
+            ConnectionPool::Oracle(handle) => {
+                let _ = oracle::close_connection(&handle).await;
+            }
         }
 
         if let Some(tunnel) = self.tunnel {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -101,6 +101,13 @@ pub struct ExecuteQueryPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct CountQueryPayload {
+    pub total_rows: u64,
+    pub execution_time: u64,
+    pub diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ServerTimePayload {
     pub value: String,
 }
@@ -421,6 +428,56 @@ pub fn execute_query(
 }
 
 #[tauri::command]
+pub fn count_query(
+    state: tauri::State<'_, DbState>,
+    conn_id: String,
+    query: String,
+) -> Result<CountQueryPayload, String> {
+    tauri::async_runtime::block_on(async {
+        let started_at = Instant::now();
+        let pool = {
+            let connections = state.connections.lock().await;
+            let connection = connections
+                .get(&conn_id)
+                .ok_or_else(|| "Connection not found".to_string())?;
+
+            if !connection.autocommit_enabled && !matches!(connection.pool, ConnectionPool::Oracle(_)) {
+                return Err("Background count is not available while autocommit is OFF.".to_string());
+            }
+
+            connection_pool_from_managed(connection)
+        };
+
+        let mut diagnostics = Vec::new();
+        let count_started = Instant::now();
+        let total_rows = match pool {
+            ConnectionPool::Postgres(pool) => postgres::count_query(&pool, &query).await?,
+            ConnectionPool::Mysql(pool) => mysql::count_query(&pool, &query).await?,
+            ConnectionPool::Oracle(handle) => {
+                let (total_rows, oracle_diagnostics) = oracle::count_query(&handle, &query).await?;
+                diagnostics.extend(oracle_diagnostics);
+                total_rows
+            }
+        };
+        diagnostics.push(format!(
+            "[db] count_query engine_ms: {}",
+            count_started.elapsed().as_millis()
+        ));
+        diagnostics.push(format!("[db] count_query total_rows: {total_rows}"));
+        diagnostics.push(format!(
+            "[db] count_query total command: {}ms",
+            started_at.elapsed().as_millis()
+        ));
+
+        Ok(CountQueryPayload {
+            total_rows,
+            execution_time: started_at.elapsed().as_millis() as u64,
+            diagnostics,
+        })
+    })
+}
+
+#[tauri::command]
 pub fn set_connection_autocommit(
     state: tauri::State<'_, DbState>,
     conn_id: String,
@@ -465,7 +522,7 @@ pub async fn get_server_time(
         ConnectionPool::Postgres(pool) => postgres::execute_query(&pool, query, None, None, None).await,
         ConnectionPool::Mysql(pool) => mysql::execute_query(&pool, query, None, None, None).await,
         ConnectionPool::Oracle(connection) => {
-            oracle::execute_query(&connection, query, None, None).await
+            oracle::execute_query(&connection, query, None, None, None).await
         }
     }?;
 
@@ -514,7 +571,7 @@ async fn execute_query_on_managed_connection(
                 mysql::execute_query(&pool, query, page, page_size, known_total_rows).await
             }
             ConnectionPool::Oracle(handle) => {
-                oracle::execute_query(&handle, query, page, page_size).await
+                oracle::execute_query(&handle, query, page, page_size, known_total_rows).await
             }
         }?;
 
@@ -584,7 +641,7 @@ async fn execute_manual_transaction_query(
                     mysql::execute_query(pool, query, page, page_size, known_total_rows).await
                 }
                 ConnectionPool::Oracle(handle) => {
-                    oracle::execute_query(handle, query, page, page_size).await
+                    oracle::execute_query(handle, query, page, page_size, known_total_rows).await
                 }
             },
         },

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -110,6 +110,13 @@ pub struct CountQueryPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct CancelQueryPayload {
+    pub execution_id: String,
+    pub cancelled: bool,
+    pub diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ServerTimePayload {
     pub value: String,
 }
@@ -476,6 +483,18 @@ pub fn count_query(
             execution_time: started_at.elapsed().as_millis() as u64,
             diagnostics,
         })
+    })
+}
+
+#[tauri::command]
+pub fn cancel_query(execution_id: String) -> Result<CancelQueryPayload, String> {
+    Ok(CancelQueryPayload {
+        execution_id: execution_id.clone(),
+        cancelled: true,
+        diagnostics: vec![
+            format!("[db] cancel_query execution_id: {execution_id}"),
+            "[db] cancel_query mode: frontend_result_ignore".into(),
+        ],
     })
 }
 

--- a/src-tauri/src/engines/mysql.rs
+++ b/src-tauri/src/engines/mysql.rs
@@ -233,6 +233,12 @@ async fn execute_query_on_pool(
                 total_rows: Some(total_rows.max(0) as u64),
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
+                has_more: Some(has_more_from_total(
+                    total_rows.max(0) as u64,
+                    normalized_page,
+                    normalized_page_size,
+                )),
+                diagnostics: Vec::new(),
             })
         } else if is_result_set_query(trimmed) {
             let rows = sqlx::query(trimmed)
@@ -282,6 +288,8 @@ async fn execute_query_on_pool(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: Vec::new(),
             })
         } else {
             let result = sqlx::query(trimmed)
@@ -301,6 +309,8 @@ async fn execute_query_on_pool(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: Vec::new(),
             })
         }
     };
@@ -387,6 +397,12 @@ async fn execute_query_on_active_connection(
                 total_rows: Some(total_rows.max(0) as u64),
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
+                has_more: Some(has_more_from_total(
+                    total_rows.max(0) as u64,
+                    normalized_page,
+                    normalized_page_size,
+                )),
+                diagnostics: Vec::new(),
             })
         } else if is_result_set_query(trimmed) {
             let rows = sqlx::query(trimmed)
@@ -436,6 +452,8 @@ async fn execute_query_on_active_connection(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: Vec::new(),
             })
         } else {
             let result = sqlx::query(trimmed)
@@ -455,6 +473,8 @@ async fn execute_query_on_active_connection(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: Vec::new(),
             })
         }
     };
@@ -501,6 +521,10 @@ fn strip_leading_sql_comments(query: &str) -> &str {
 
         return rest;
     }
+}
+
+fn has_more_from_total(total_rows: u64, page: u32, page_size: u32) -> bool {
+    u64::from(page) * u64::from(page_size) < total_rows
 }
 
 fn mysql_value_to_json(row: &sqlx::mysql::MySqlRow, index: usize) -> Value {

--- a/src-tauri/src/engines/mysql.rs
+++ b/src-tauri/src/engines/mysql.rs
@@ -126,6 +126,28 @@ pub async fn execute_query_on_connection(
     .await
 }
 
+pub async fn count_query(pool: &MySqlPool, query: &str) -> Result<u64, String> {
+    let trimmed = query.trim();
+    if !is_paginable_result_query(trimmed) {
+        return Err("Only SELECT/WITH queries can be counted.".into());
+    }
+
+    let count_sql =
+        format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
+    let execution = async {
+        sqlx::query_scalar::<_, i64>(&count_sql)
+            .fetch_one(pool)
+            .await
+            .map(|value| value.max(0) as u64)
+            .map_err(|error| error.to_string())
+    };
+
+    match tokio::time::timeout(Duration::from_secs(30), execution).await {
+        Ok(result) => result,
+        Err(_) => Err("Count query timed out after 30 seconds.".into()),
+    }
+}
+
 pub async fn begin_transaction(connection: &mut PoolConnection<MySql>) -> Result<(), String> {
     sqlx::query("START TRANSACTION")
         .execute(connection.as_mut())
@@ -161,35 +183,21 @@ async fn execute_query_on_pool(
     let started_at = Instant::now();
     let normalized_page = page.max(1);
     let normalized_page_size = page_size.clamp(1, 1_000);
+    let fetch_page_size = normalized_page_size + 1;
     let offset = u64::from(normalized_page - 1) * u64::from(normalized_page_size);
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
             let paged_sql = format!(
-                "SELECT * FROM ({trimmed}) AS blacktable_page LIMIT {normalized_page_size} OFFSET {offset}"
+                "SELECT * FROM ({trimmed}) AS blacktable_page LIMIT {fetch_page_size} OFFSET {offset}"
             );
-            let count_sql =
-                format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
+            let rows = sqlx::query(&paged_sql)
+                .fetch_all(pool)
+                .await
+                .map_err(|error| error.to_string())?;
 
-            // Run paged data and COUNT in parallel.
-            // When total rows is already known (page navigation), skip the COUNT query.
-            let (rows, total_rows) = tokio::try_join!(
-                async {
-                    sqlx::query(&paged_sql)
-                        .fetch_all(pool)
-                        .await
-                        .map_err(|error| error.to_string())
-                },
-                async {
-                    match known_total_rows {
-                        Some(known) => Ok::<i64, String>(known as i64),
-                        None => sqlx::query_scalar::<_, i64>(&count_sql)
-                            .fetch_one(pool)
-                            .await
-                            .map_err(|error| error.to_string()),
-                    }
-                },
-            )?;
+            let data_has_more = rows.len() > normalized_page_size as usize;
+            let rows = trim_extra_row(rows, normalized_page_size);
 
             let columns = rows
                 .first()
@@ -230,14 +238,15 @@ async fn execute_query_on_pool(
                 rows,
                 execution_time: started_at.elapsed().as_millis() as u64,
                 summary: None,
-                total_rows: Some(total_rows.max(0) as u64),
+                total_rows: known_total_rows,
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
-                has_more: Some(has_more_from_total(
-                    total_rows.max(0) as u64,
-                    normalized_page,
-                    normalized_page_size,
-                )),
+                has_more: Some(
+                    data_has_more
+                        || known_total_rows.is_some_and(|total_rows| {
+                            has_more_from_total(total_rows, normalized_page, normalized_page_size)
+                        }),
+                ),
                 diagnostics: Vec::new(),
             })
         } else if is_result_set_query(trimmed) {
@@ -332,28 +341,22 @@ async fn execute_query_on_active_connection(
     let started_at = Instant::now();
     let normalized_page = page.max(1);
     let normalized_page_size = page_size.clamp(1, 1_000);
+    let fetch_page_size = normalized_page_size + 1;
     let offset = u64::from(normalized_page - 1) * u64::from(normalized_page_size);
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
             let paged_sql = format!(
-                "SELECT * FROM ({trimmed}) AS blacktable_page LIMIT {normalized_page_size} OFFSET {offset}"
+                "SELECT * FROM ({trimmed}) AS blacktable_page LIMIT {fetch_page_size} OFFSET {offset}"
             );
-            let count_sql =
-                format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
 
-            // Single connection — cannot parallelize; skip COUNT when already known.
             let rows = sqlx::query(&paged_sql)
                 .fetch_all(&mut *connection)
                 .await
                 .map_err(|error| error.to_string())?;
-            let total_rows = match known_total_rows {
-                Some(known) => known as i64,
-                None => sqlx::query_scalar::<_, i64>(&count_sql)
-                    .fetch_one(&mut *connection)
-                    .await
-                    .map_err(|error| error.to_string())?,
-            };
+
+            let data_has_more = rows.len() > normalized_page_size as usize;
+            let rows = trim_extra_row(rows, normalized_page_size);
 
             let columns = rows
                 .first()
@@ -394,14 +397,15 @@ async fn execute_query_on_active_connection(
                 rows,
                 execution_time: started_at.elapsed().as_millis() as u64,
                 summary: None,
-                total_rows: Some(total_rows.max(0) as u64),
+                total_rows: known_total_rows,
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
-                has_more: Some(has_more_from_total(
-                    total_rows.max(0) as u64,
-                    normalized_page,
-                    normalized_page_size,
-                )),
+                has_more: Some(
+                    data_has_more
+                        || known_total_rows.is_some_and(|total_rows| {
+                            has_more_from_total(total_rows, normalized_page, normalized_page_size)
+                        }),
+                ),
                 diagnostics: Vec::new(),
             })
         } else if is_result_set_query(trimmed) {
@@ -525,6 +529,11 @@ fn strip_leading_sql_comments(query: &str) -> &str {
 
 fn has_more_from_total(total_rows: u64, page: u32, page_size: u32) -> bool {
     u64::from(page) * u64::from(page_size) < total_rows
+}
+
+fn trim_extra_row(mut rows: Vec<sqlx::mysql::MySqlRow>, page_size: u32) -> Vec<sqlx::mysql::MySqlRow> {
+    rows.truncate(page_size as usize);
+    rows
 }
 
 fn mysql_value_to_json(row: &sqlx::mysql::MySqlRow, index: usize) -> Value {

--- a/src-tauri/src/engines/oracle.rs
+++ b/src-tauri/src/engines/oracle.rs
@@ -77,6 +77,7 @@ struct OracleRequest<'a> {
     query: Option<&'a str>,
     page: Option<u32>,
     page_size: Option<u32>,
+    known_total_rows: Option<u64>,
     schema: Option<&'a str>,
     table: Option<&'a str>,
 }
@@ -109,23 +110,23 @@ pub fn create_handle(
 }
 
 pub async fn test_connection(handle: &OracleConnectionHandle) -> Result<(), String> {
-    invoke_sidecar("test", handle, None, None, None, None, None).map(|_| ())
+    invoke_sidecar("test", handle, None, None, None, None, None, None).map(|_| ())
 }
 
 pub async fn open_connection(
     handle: &OracleConnectionHandle,
 ) -> Result<OracleConnectionHandle, String> {
-    invoke_sidecar("open", handle, None, None, None, None, None)?;
+    invoke_sidecar("open", handle, None, None, None, None, None, None)?;
     Ok(handle.clone())
 }
 
 pub async fn list_databases(handle: &OracleConnectionHandle) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listDatabases", handle, None, None, None, None, None)?;
+    let response = invoke_sidecar("listDatabases", handle, None, None, None, None, None, None)?;
     Ok(response.items.unwrap_or_default())
 }
 
 pub async fn list_schemas(handle: &OracleConnectionHandle) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listSchemas", handle, None, None, None, None, None)?;
+    let response = invoke_sidecar("listSchemas", handle, None, None, None, None, None, None)?;
     Ok(response.items.unwrap_or_default())
 }
 
@@ -133,7 +134,7 @@ pub async fn list_tables(
     handle: &OracleConnectionHandle,
     schema: &str,
 ) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listTables", handle, None, None, None, Some(schema), None)?;
+    let response = invoke_sidecar("listTables", handle, None, None, None, None, Some(schema), None)?;
     Ok(response.items.unwrap_or_default())
 }
 
@@ -142,7 +143,7 @@ pub async fn list_columns(
     schema: &str,
     table: &str,
 ) -> Result<Vec<ColumnDef>, String> {
-    let response = invoke_sidecar("listColumns", handle, None, None, None, Some(schema), Some(table))?;
+    let response = invoke_sidecar("listColumns", handle, None, None, None, None, Some(schema), Some(table))?;
     Ok(response.column_defs.unwrap_or_default())
 }
 
@@ -151,6 +152,7 @@ pub async fn execute_query(
     query: &str,
     page: Option<u32>,
     page_size: Option<u32>,
+    known_total_rows: Option<u64>,
 ) -> Result<QueryResult, String> {
     let started_at = Instant::now();
     let sidecar_started = Instant::now();
@@ -160,6 +162,7 @@ pub async fn execute_query(
         Some(query),
         page,
         page_size,
+        known_total_rows,
         None,
         None,
     )?;
@@ -186,6 +189,30 @@ pub async fn execute_query(
         has_more: response.has_more,
         diagnostics,
     })
+}
+
+pub async fn count_query(handle: &OracleConnectionHandle, query: &str) -> Result<(u64, Vec<String>), String> {
+    let sidecar_started = Instant::now();
+    let response = invoke_sidecar(
+        "countQuery",
+        handle,
+        Some(query),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+    let mut diagnostics = response.diagnostics.unwrap_or_default();
+    diagnostics.push(format!(
+        "[oracle] count_sidecar_roundtrip_ms: {}",
+        sidecar_started.elapsed().as_millis()
+    ));
+
+    response
+        .total_rows
+        .map(|total_rows| (total_rows, diagnostics))
+        .ok_or_else(|| "Oracle count query did not return total_rows.".to_string())
 }
 
 pub fn sidecar_root() -> Result<PathBuf, String> {
@@ -217,6 +244,7 @@ fn invoke_sidecar(
     query: Option<&str>,
     page: Option<u32>,
     page_size: Option<u32>,
+    known_total_rows: Option<u64>,
     schema: Option<&str>,
     table: Option<&str>,
 ) -> Result<OracleSuccessResponse, String> {
@@ -244,6 +272,7 @@ fn invoke_sidecar(
         query,
         page,
         page_size,
+        known_total_rows,
         schema,
         table,
     };

--- a/src-tauri/src/engines/oracle.rs
+++ b/src-tauri/src/engines/oracle.rs
@@ -57,7 +57,10 @@ struct OracleSuccessResponse {
     total_rows: Option<u64>,
     page: Option<u32>,
     page_size: Option<u32>,
+    #[serde(default)]
+    has_more: Option<bool>,
     column_defs: Option<Vec<ColumnDef>>,
+    diagnostics: Option<Vec<String>>,
 }
 
 /// Request sent to the persistent sidecar over stdin (one JSON line per call).
@@ -150,6 +153,7 @@ pub async fn execute_query(
     page_size: Option<u32>,
 ) -> Result<QueryResult, String> {
     let started_at = Instant::now();
+    let sidecar_started = Instant::now();
     let response = invoke_sidecar(
         "executeQuery",
         handle,
@@ -159,11 +163,19 @@ pub async fn execute_query(
         None,
         None,
     )?;
+    let sidecar_ms = sidecar_started.elapsed().as_millis();
+
+    let rows = response.rows.unwrap_or_default();
+    let mut diagnostics = response.diagnostics.unwrap_or_default();
+    diagnostics.extend([
+        format!("[oracle] sidecar_roundtrip_ms: {sidecar_ms}"),
+        format!("[oracle] rows_returned: {}", rows.len()),
+    ]);
 
     Ok(QueryResult {
         columns: response.columns.unwrap_or_default(),
         column_meta: response.column_meta.unwrap_or_default(),
-        rows: response.rows.unwrap_or_default(),
+        rows,
         execution_time: response
             .execution_time
             .unwrap_or_else(|| started_at.elapsed().as_millis() as u64),
@@ -171,6 +183,8 @@ pub async fn execute_query(
         total_rows: response.total_rows,
         page: response.page,
         page_size: response.page_size,
+        has_more: response.has_more,
+        diagnostics,
     })
 }
 

--- a/src-tauri/src/engines/oracle.rs
+++ b/src-tauri/src/engines/oracle.rs
@@ -110,27 +110,33 @@ pub fn create_handle(
 }
 
 pub async fn test_connection(handle: &OracleConnectionHandle) -> Result<(), String> {
-    invoke_sidecar("test", handle, None, None, None, None, None, None).map(|_| ())
+    invoke_sidecar_blocking("test", handle.clone(), None, None, None, None, None, None)
+        .await
+        .map(|_| ())
 }
 
 pub async fn open_connection(
     handle: &OracleConnectionHandle,
 ) -> Result<OracleConnectionHandle, String> {
-    invoke_sidecar("open", handle, None, None, None, None, None, None)?;
+    invoke_sidecar_blocking("open", handle.clone(), None, None, None, None, None, None).await?;
     Ok(handle.clone())
 }
 
 pub async fn close_connection(handle: &OracleConnectionHandle) -> Result<(), String> {
-    invoke_sidecar("close", handle, None, None, None, None, None, None).map(|_| ())
+    invoke_sidecar_blocking("close", handle.clone(), None, None, None, None, None, None)
+        .await
+        .map(|_| ())
 }
 
 pub async fn list_databases(handle: &OracleConnectionHandle) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listDatabases", handle, None, None, None, None, None, None)?;
+    let response =
+        invoke_sidecar_blocking("listDatabases", handle.clone(), None, None, None, None, None, None).await?;
     Ok(response.items.unwrap_or_default())
 }
 
 pub async fn list_schemas(handle: &OracleConnectionHandle) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listSchemas", handle, None, None, None, None, None, None)?;
+    let response =
+        invoke_sidecar_blocking("listSchemas", handle.clone(), None, None, None, None, None, None).await?;
     Ok(response.items.unwrap_or_default())
 }
 
@@ -138,7 +144,17 @@ pub async fn list_tables(
     handle: &OracleConnectionHandle,
     schema: &str,
 ) -> Result<Vec<String>, String> {
-    let response = invoke_sidecar("listTables", handle, None, None, None, None, Some(schema), None)?;
+    let response = invoke_sidecar_blocking(
+        "listTables",
+        handle.clone(),
+        None,
+        None,
+        None,
+        None,
+        Some(schema.to_string()),
+        None,
+    )
+    .await?;
     Ok(response.items.unwrap_or_default())
 }
 
@@ -147,7 +163,17 @@ pub async fn list_columns(
     schema: &str,
     table: &str,
 ) -> Result<Vec<ColumnDef>, String> {
-    let response = invoke_sidecar("listColumns", handle, None, None, None, None, Some(schema), Some(table))?;
+    let response = invoke_sidecar_blocking(
+        "listColumns",
+        handle.clone(),
+        None,
+        None,
+        None,
+        None,
+        Some(schema.to_string()),
+        Some(table.to_string()),
+    )
+    .await?;
     Ok(response.column_defs.unwrap_or_default())
 }
 
@@ -160,16 +186,17 @@ pub async fn execute_query(
 ) -> Result<QueryResult, String> {
     let started_at = Instant::now();
     let sidecar_started = Instant::now();
-    let response = invoke_sidecar(
+    let response = invoke_sidecar_blocking(
         "executeQuery",
-        handle,
-        Some(query),
+        handle.clone(),
+        Some(query.to_string()),
         page,
         page_size,
         known_total_rows,
         None,
         None,
-    )?;
+    )
+    .await?;
     let sidecar_ms = sidecar_started.elapsed().as_millis();
 
     let rows = response.rows.unwrap_or_default();
@@ -197,16 +224,17 @@ pub async fn execute_query(
 
 pub async fn count_query(handle: &OracleConnectionHandle, query: &str) -> Result<(u64, Vec<String>), String> {
     let sidecar_started = Instant::now();
-    let response = invoke_sidecar(
+    let response = invoke_sidecar_blocking(
         "countQuery",
-        handle,
-        Some(query),
+        handle.clone(),
+        Some(query.to_string()),
         None,
         None,
         None,
         None,
         None,
-    )?;
+    )
+    .await?;
     let mut diagnostics = response.diagnostics.unwrap_or_default();
     diagnostics.push(format!(
         "[oracle] count_sidecar_roundtrip_ms: {}",
@@ -304,6 +332,32 @@ fn invoke_sidecar(
                 .map_err(|_| humanize_oracle_sidecar_error(&io_error))
         }
     }
+}
+
+async fn invoke_sidecar_blocking(
+    command: &'static str,
+    handle: OracleConnectionHandle,
+    query: Option<String>,
+    page: Option<u32>,
+    page_size: Option<u32>,
+    known_total_rows: Option<u64>,
+    schema: Option<String>,
+    table: Option<String>,
+) -> Result<OracleSuccessResponse, String> {
+    tokio::task::spawn_blocking(move || {
+        invoke_sidecar(
+            command,
+            &handle,
+            query.as_deref(),
+            page,
+            page_size,
+            known_total_rows,
+            schema.as_deref(),
+            table.as_deref(),
+        )
+    })
+    .await
+    .map_err(|error| format!("Oracle sidecar task failed: {error}"))?
 }
 
 /// Writes one JSON request line to the sidecar's stdin and reads one response line from stdout.

--- a/src-tauri/src/engines/oracle.rs
+++ b/src-tauri/src/engines/oracle.rs
@@ -120,6 +120,10 @@ pub async fn open_connection(
     Ok(handle.clone())
 }
 
+pub async fn close_connection(handle: &OracleConnectionHandle) -> Result<(), String> {
+    invoke_sidecar("close", handle, None, None, None, None, None, None).map(|_| ())
+}
+
 pub async fn list_databases(handle: &OracleConnectionHandle) -> Result<Vec<String>, String> {
     let response = invoke_sidecar("listDatabases", handle, None, None, None, None, None, None)?;
     Ok(response.items.unwrap_or_default())

--- a/src-tauri/src/engines/postgres.rs
+++ b/src-tauri/src/engines/postgres.rs
@@ -173,6 +173,7 @@ async fn execute_query_on_pool(
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
+            let prepare_started = Instant::now();
             let count_sql =
                 format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
 
@@ -181,26 +182,35 @@ async fn execute_query_on_pool(
                  FROM ({trimmed}) AS blacktable_page
                  LIMIT {normalized_page_size} OFFSET {offset}"
             );
+            let prepare_ms = prepare_started.elapsed().as_millis();
 
             // Run COUNT and data queries in parallel.
             // When total rows is already known (page navigation), skip the COUNT query.
-            let (total_rows, rows_raw) = tokio::try_join!(
+            let ((total_rows, count_ms), (rows_raw, data_ms)) = tokio::try_join!(
                 async {
+                    let count_started = Instant::now();
                     match known_total_rows {
-                        Some(known) => Ok::<i64, String>(known as i64),
-                        None => fetch_total_rows_on_pool(pool, &count_sql).await,
+                        Some(known) => Ok::<(i64, u128), String>((known as i64, 0)),
+                        None => fetch_total_rows_on_pool(pool, &count_sql)
+                            .await
+                            .map(|total| (total, count_started.elapsed().as_millis())),
                     }
                 },
                 async {
+                    let data_started = Instant::now();
                     raw_sql(&data_sql)
                         .fetch_all(pool)
                         .await
+                        .map(|rows| (rows, data_started.elapsed().as_millis()))
                         .map_err(|error| error.to_string())
                 },
             )?;
 
+            let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
+            let rows_returned = rows.len();
+            let serialize_ms = serialize_started.elapsed().as_millis();
 
             Ok(QueryResult {
                 columns,
@@ -211,20 +221,39 @@ async fn execute_query_on_pool(
                 total_rows: Some(total_rows.max(0) as u64),
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
+                has_more: Some(has_more_from_total(
+                    total_rows.max(0) as u64,
+                    normalized_page,
+                    normalized_page_size,
+                )),
+                diagnostics: vec![
+                    format!("[postgres] prepare_ms: {prepare_ms}"),
+                    format!("[postgres] count_ms: {count_ms}"),
+                    format!("[postgres] data_ms: {data_ms}"),
+                    format!("[postgres] serialize_ms: {serialize_ms}"),
+                    format!("[postgres] rows_returned: {rows_returned}"),
+                ],
             })
         } else if is_result_set_query(trimmed) {
+            let prepare_started = Instant::now();
             let data_sql = format!(
                 "SELECT to_jsonb(blacktable_row) AS __blacktable_json, blacktable_row.*
                  FROM ({trimmed}) AS blacktable_row"
             );
+            let prepare_ms = prepare_started.elapsed().as_millis();
 
+            let data_started = Instant::now();
             let rows_raw = raw_sql(&data_sql)
                 .fetch_all(pool)
                 .await
                 .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
+            let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
+            let rows_returned = rows.len();
+            let serialize_ms = serialize_started.elapsed().as_millis();
 
             Ok(QueryResult {
                 columns,
@@ -235,18 +264,36 @@ async fn execute_query_on_pool(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: vec![
+                    format!("[postgres] prepare_ms: {prepare_ms}"),
+                    "[postgres] count_ms: 0".into(),
+                    format!("[postgres] data_ms: {data_ms}"),
+                    format!("[postgres] serialize_ms: {serialize_ms}"),
+                    format!("[postgres] rows_returned: {rows_returned}"),
+                ],
             })
         } else {
+            let data_started = Instant::now();
             let result = raw_sql(trimmed)
                 .execute(pool)
                 .await
                 .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
-            Ok(build_command_result(
+            let mut result = build_command_result(
                 trimmed,
                 result.rows_affected(),
                 started_at.elapsed().as_millis() as u64,
-            ))
+            );
+            result.diagnostics = vec![
+                "[postgres] prepare_ms: 0".into(),
+                "[postgres] count_ms: 0".into(),
+                format!("[postgres] data_ms: {data_ms}"),
+                "[postgres] serialize_ms: 0".into(),
+                format!("[postgres] rows_returned: {}", result.rows.len()),
+            ];
+            Ok(result)
         }
     };
 
@@ -273,6 +320,7 @@ async fn execute_query_on_active_connection(
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
+            let prepare_started = Instant::now();
             let count_sql =
                 format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
 
@@ -281,20 +329,32 @@ async fn execute_query_on_active_connection(
                  FROM ({trimmed}) AS blacktable_page
                  LIMIT {normalized_page_size} OFFSET {offset}"
             );
+            let prepare_ms = prepare_started.elapsed().as_millis();
 
             // Single connection — cannot parallelize; skip COUNT when already known.
+            let count_started = Instant::now();
             let total_rows = match known_total_rows {
                 Some(known) => known as i64,
                 None => fetch_total_rows_on_connection(connection, &count_sql).await?,
             };
+            let count_ms = if known_total_rows.is_some() {
+                0
+            } else {
+                count_started.elapsed().as_millis()
+            };
 
+            let data_started = Instant::now();
             let rows_raw = raw_sql(&data_sql)
                 .fetch_all(&mut *connection)
                 .await
                 .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
+            let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
+            let rows_returned = rows.len();
+            let serialize_ms = serialize_started.elapsed().as_millis();
 
             Ok(QueryResult {
                 columns,
@@ -305,20 +365,39 @@ async fn execute_query_on_active_connection(
                 total_rows: Some(total_rows.max(0) as u64),
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
+                has_more: Some(has_more_from_total(
+                    total_rows.max(0) as u64,
+                    normalized_page,
+                    normalized_page_size,
+                )),
+                diagnostics: vec![
+                    format!("[postgres] prepare_ms: {prepare_ms}"),
+                    format!("[postgres] count_ms: {count_ms}"),
+                    format!("[postgres] data_ms: {data_ms}"),
+                    format!("[postgres] serialize_ms: {serialize_ms}"),
+                    format!("[postgres] rows_returned: {rows_returned}"),
+                ],
             })
         } else if is_result_set_query(trimmed) {
+            let prepare_started = Instant::now();
             let data_sql = format!(
                 "SELECT to_jsonb(blacktable_row) AS __blacktable_json, blacktable_row.*
                  FROM ({trimmed}) AS blacktable_row"
             );
+            let prepare_ms = prepare_started.elapsed().as_millis();
 
+            let data_started = Instant::now();
             let rows_raw = raw_sql(&data_sql)
                 .fetch_all(&mut *connection)
                 .await
                 .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
+            let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
+            let rows_returned = rows.len();
+            let serialize_ms = serialize_started.elapsed().as_millis();
 
             Ok(QueryResult {
                 columns,
@@ -329,18 +408,36 @@ async fn execute_query_on_active_connection(
                 total_rows: None,
                 page: None,
                 page_size: None,
+                has_more: None,
+                diagnostics: vec![
+                    format!("[postgres] prepare_ms: {prepare_ms}"),
+                    "[postgres] count_ms: 0".into(),
+                    format!("[postgres] data_ms: {data_ms}"),
+                    format!("[postgres] serialize_ms: {serialize_ms}"),
+                    format!("[postgres] rows_returned: {rows_returned}"),
+                ],
             })
         } else {
+            let data_started = Instant::now();
             let result = raw_sql(trimmed)
                 .execute(&mut *connection)
                 .await
                 .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
-            Ok(build_command_result(
+            let mut result = build_command_result(
                 trimmed,
                 result.rows_affected(),
                 started_at.elapsed().as_millis() as u64,
-            ))
+            );
+            result.diagnostics = vec![
+                "[postgres] prepare_ms: 0".into(),
+                "[postgres] count_ms: 0".into(),
+                format!("[postgres] data_ms: {data_ms}"),
+                "[postgres] serialize_ms: 0".into(),
+                format!("[postgres] rows_returned: {}", result.rows.len()),
+            ];
+            Ok(result)
         }
     };
 
@@ -397,6 +494,8 @@ fn build_command_result(query: &str, rows_affected: u64, execution_time: u64) ->
             total_rows: None,
             page: None,
             page_size: None,
+            has_more: None,
+            diagnostics: Vec::new(),
         };
     }
 
@@ -412,7 +511,13 @@ fn build_command_result(query: &str, rows_affected: u64, execution_time: u64) ->
         total_rows: None,
         page: None,
         page_size: None,
+        has_more: None,
+        diagnostics: Vec::new(),
     }
+}
+
+fn has_more_from_total(total_rows: u64, page: u32, page_size: u32) -> bool {
+    u64::from(page) * u64::from(page_size) < total_rows
 }
 
 fn decode_jsonb_rows(rows: Vec<sqlx::postgres::PgRow>) -> Result<Vec<Value>, String> {

--- a/src-tauri/src/engines/postgres.rs
+++ b/src-tauri/src/engines/postgres.rs
@@ -134,6 +134,37 @@ pub async fn execute_query_on_connection(
     .await
 }
 
+pub async fn count_query(pool: &PgPool, query: &str) -> Result<u64, String> {
+    let trimmed = query.trim();
+    if !is_paginable_result_query(trimmed) {
+        return Err("Only SELECT/WITH queries can be counted.".into());
+    }
+
+    let count_sql =
+        format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
+    let execution = async {
+        let rows = raw_sql(&count_sql)
+            .fetch_all(pool)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let row = rows.first().ok_or_else(|| {
+            "Failed to decode PostgreSQL total row count: no rows returned".to_string()
+        })?;
+
+        row.try_get::<i64, _>("blacktable_total")
+            .map(|value| value.max(0) as u64)
+            .map_err(|error| format!("Failed to decode PostgreSQL total row count: {error}"))
+    };
+
+    match tokio::time::timeout(Duration::from_secs(QUERY_TIMEOUT_SECONDS), execution).await {
+        Ok(result) => result,
+        Err(_) => Err(format!(
+            "Count query timed out after {QUERY_TIMEOUT_SECONDS} seconds."
+        )),
+    }
+}
+
 pub async fn begin_transaction(connection: &mut PoolConnection<Postgres>) -> Result<(), String> {
     raw_sql("BEGIN")
         .execute(connection.as_mut())
@@ -169,43 +200,29 @@ async fn execute_query_on_pool(
     let started_at = Instant::now();
     let normalized_page = page.max(1);
     let normalized_page_size = page_size.clamp(1, 1_000);
+    let fetch_page_size = normalized_page_size + 1;
     let offset = u64::from(normalized_page - 1) * u64::from(normalized_page_size);
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
             let prepare_started = Instant::now();
-            let count_sql =
-                format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
-
             let data_sql = format!(
                 "SELECT to_jsonb(blacktable_page) AS __blacktable_json, blacktable_page.*
                  FROM ({trimmed}) AS blacktable_page
-                 LIMIT {normalized_page_size} OFFSET {offset}"
+                 LIMIT {fetch_page_size} OFFSET {offset}"
             );
             let prepare_ms = prepare_started.elapsed().as_millis();
 
-            // Run COUNT and data queries in parallel.
-            // When total rows is already known (page navigation), skip the COUNT query.
-            let ((total_rows, count_ms), (rows_raw, data_ms)) = tokio::try_join!(
-                async {
-                    let count_started = Instant::now();
-                    match known_total_rows {
-                        Some(known) => Ok::<(i64, u128), String>((known as i64, 0)),
-                        None => fetch_total_rows_on_pool(pool, &count_sql)
-                            .await
-                            .map(|total| (total, count_started.elapsed().as_millis())),
-                    }
-                },
-                async {
-                    let data_started = Instant::now();
-                    raw_sql(&data_sql)
-                        .fetch_all(pool)
-                        .await
-                        .map(|rows| (rows, data_started.elapsed().as_millis()))
-                        .map_err(|error| error.to_string())
-                },
-            )?;
+            let count_ms = 0;
+            let data_started = Instant::now();
+            let rows_raw = raw_sql(&data_sql)
+                .fetch_all(pool)
+                .await
+                .map_err(|error| error.to_string())?;
+            let data_ms = data_started.elapsed().as_millis();
 
+            let data_has_more = rows_raw.len() > normalized_page_size as usize;
+            let rows_raw = trim_extra_row(rows_raw, normalized_page_size);
             let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
@@ -218,14 +235,15 @@ async fn execute_query_on_pool(
                 rows,
                 execution_time: started_at.elapsed().as_millis() as u64,
                 summary: None,
-                total_rows: Some(total_rows.max(0) as u64),
+                total_rows: known_total_rows,
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
-                has_more: Some(has_more_from_total(
-                    total_rows.max(0) as u64,
-                    normalized_page,
-                    normalized_page_size,
-                )),
+                has_more: Some(
+                    data_has_more
+                        || known_total_rows.is_some_and(|total_rows| {
+                            has_more_from_total(total_rows, normalized_page, normalized_page_size)
+                        }),
+                ),
                 diagnostics: vec![
                     format!("[postgres] prepare_ms: {prepare_ms}"),
                     format!("[postgres] count_ms: {count_ms}"),
@@ -316,33 +334,20 @@ async fn execute_query_on_active_connection(
     let started_at = Instant::now();
     let normalized_page = page.max(1);
     let normalized_page_size = page_size.clamp(1, 1_000);
+    let fetch_page_size = normalized_page_size + 1;
     let offset = u64::from(normalized_page - 1) * u64::from(normalized_page_size);
 
     let execution = async {
         if is_paginable_result_query(trimmed) {
             let prepare_started = Instant::now();
-            let count_sql =
-                format!("SELECT COUNT(*) AS blacktable_total FROM ({trimmed}) AS blacktable_count");
-
             let data_sql = format!(
                 "SELECT to_jsonb(blacktable_page) AS __blacktable_json, blacktable_page.*
                  FROM ({trimmed}) AS blacktable_page
-                 LIMIT {normalized_page_size} OFFSET {offset}"
+                 LIMIT {fetch_page_size} OFFSET {offset}"
             );
             let prepare_ms = prepare_started.elapsed().as_millis();
 
-            // Single connection — cannot parallelize; skip COUNT when already known.
-            let count_started = Instant::now();
-            let total_rows = match known_total_rows {
-                Some(known) => known as i64,
-                None => fetch_total_rows_on_connection(connection, &count_sql).await?,
-            };
-            let count_ms = if known_total_rows.is_some() {
-                0
-            } else {
-                count_started.elapsed().as_millis()
-            };
-
+            let count_ms = 0;
             let data_started = Instant::now();
             let rows_raw = raw_sql(&data_sql)
                 .fetch_all(&mut *connection)
@@ -350,6 +355,8 @@ async fn execute_query_on_active_connection(
                 .map_err(|error| error.to_string())?;
             let data_ms = data_started.elapsed().as_millis();
 
+            let data_has_more = rows_raw.len() > normalized_page_size as usize;
+            let rows_raw = trim_extra_row(rows_raw, normalized_page_size);
             let serialize_started = Instant::now();
             let (columns, column_meta) = extract_columns_and_meta_from_jsonb(&rows_raw);
             let rows = decode_jsonb_rows(rows_raw)?;
@@ -362,14 +369,15 @@ async fn execute_query_on_active_connection(
                 rows,
                 execution_time: started_at.elapsed().as_millis() as u64,
                 summary: None,
-                total_rows: Some(total_rows.max(0) as u64),
+                total_rows: known_total_rows,
                 page: Some(normalized_page),
                 page_size: Some(normalized_page_size),
-                has_more: Some(has_more_from_total(
-                    total_rows.max(0) as u64,
-                    normalized_page,
-                    normalized_page_size,
-                )),
+                has_more: Some(
+                    data_has_more
+                        || known_total_rows.is_some_and(|total_rows| {
+                            has_more_from_total(total_rows, normalized_page, normalized_page_size)
+                        }),
+                ),
                 diagnostics: vec![
                     format!("[postgres] prepare_ms: {prepare_ms}"),
                     format!("[postgres] count_ms: {count_ms}"),
@@ -449,37 +457,6 @@ async fn execute_query_on_active_connection(
     }
 }
 
-async fn fetch_total_rows_on_pool(pool: &PgPool, sql: &str) -> Result<i64, String> {
-    let rows = raw_sql(sql)
-        .fetch_all(pool)
-        .await
-        .map_err(|error| error.to_string())?;
-
-    let row = rows
-        .first()
-        .ok_or_else(|| "Failed to decode PostgreSQL total row count: no rows returned".to_string())?;
-
-    row.try_get::<i64, _>("blacktable_total")
-        .map_err(|error| format!("Failed to decode PostgreSQL total row count: {error}"))
-}
-
-async fn fetch_total_rows_on_connection(
-    connection: &mut PgConnection,
-    sql: &str,
-) -> Result<i64, String> {
-    let rows = raw_sql(sql)
-        .fetch_all(&mut *connection)
-        .await
-        .map_err(|error| error.to_string())?;
-
-    let row = rows
-        .first()
-        .ok_or_else(|| "Failed to decode PostgreSQL total row count: no rows returned".to_string())?;
-
-    row.try_get::<i64, _>("blacktable_total")
-        .map_err(|error| format!("Failed to decode PostgreSQL total row count: {error}"))
-}
-
 fn build_command_result(query: &str, rows_affected: u64, execution_time: u64) -> QueryResult {
     if is_do_block(query) {
         return QueryResult {
@@ -518,6 +495,14 @@ fn build_command_result(query: &str, rows_affected: u64, execution_time: u64) ->
 
 fn has_more_from_total(total_rows: u64, page: u32, page_size: u32) -> bool {
     u64::from(page) * u64::from(page_size) < total_rows
+}
+
+fn trim_extra_row(
+    mut rows: Vec<sqlx::postgres::PgRow>,
+    page_size: u32,
+) -> Vec<sqlx::postgres::PgRow> {
+    rows.truncate(page_size as usize);
+    rows
 }
 
 fn decode_jsonb_rows(rows: Vec<sqlx::postgres::PgRow>) -> Result<Vec<Value>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -295,6 +295,7 @@ pub fn run() {
             db::list_tables,
             db::list_columns,
             db::execute_query,
+            db::count_query,
             db::set_connection_autocommit,
             db::get_server_time,
             db::list_query_history,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -296,6 +296,7 @@ pub fn run() {
             db::list_columns,
             db::execute_query,
             db::count_query,
+            db::cancel_query,
             db::set_connection_autocommit,
             db::get_server_time,
             db::list_query_history,

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -217,12 +217,14 @@ export default function QueryWorkspace() {
   const [focusNewRowToken, setFocusNewRowToken] = useState(0);
   const [historyRefreshToken, setHistoryRefreshToken] = useState(0);
   const [gridFullscreen, setGridFullscreen] = useState(false);
+  const [resultsCollapsed, setResultsCollapsed] = useState(false);
   const [activePanel, setActivePanel] = useState<'results' | 'logs'>('results');
   const editErrorTimeoutRef = useRef<number | null>(null);
   const executeQueryRef = useRef<() => void>(() => {});
   const editorRef = useRef<any>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const connectionMenuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const quickFilterInputRef = useRef<HTMLInputElement | null>(null);
   const tabDragRef = useRef<{ tabId: string; startX: number; dragging: boolean } | null>(null);
   const suppressTabClickRef = useRef(false);
   const lastCursorPositionRef = useRef<{ lineNumber: number; column: number } | null>(null);
@@ -412,6 +414,7 @@ export default function QueryWorkspace() {
       setLoading(true);
       setTabError(activeTabId, null);
       setActivePanel('results');
+      setResultsCollapsed(false);
     });
     return window.performance.now();
   }, [activeTabId, setSemanticBackgroundState, setTabError]);
@@ -1380,6 +1383,7 @@ export default function QueryWorkspace() {
     try {
       await ensureExecutionConnectionReady(resolvedConnectionId);
 
+      const pendingSql: string[] = [];
       for (const [row, changes] of pendingRowEdits.entries()) {
         if (!pkCols.length) continue;
         const sql = buildMultiColUpdateSql(
@@ -1390,24 +1394,30 @@ export default function QueryWorkspace() {
           pkCols,
           engine ?? 'postgres',
         );
-        const payload = await invoke<ExecuteQueryPayload>('execute_query', {
-          connId: resolvedConnectionId,
-          query: sql,
-          page: 1,
-          pageSize: 1,
-        });
-        syncTransactionState(resolvedConnectionId, payload);
-        appendDiagnostics(resolvedConnectionId, payload.diagnostics);
+        pendingSql.push(sql);
       }
 
       for (const newRow of pendingNewRows) {
-        const sql = buildInsertSql(
+        pendingSql.push(buildInsertSql(
           activeSourceTable.schemaName,
           activeSourceTable.tableName,
           newRow,
           activeResult.column_meta ?? [],
           engine ?? 'postgres',
-        );
+        ));
+      }
+
+      if (!pendingSql.length) {
+        return;
+      }
+
+      const preview = pendingSql.slice(0, 12).join('\n\n');
+      const suffix = pendingSql.length > 12 ? `\n\n... +${pendingSql.length - 12} comandos` : '';
+      if (!window.confirm(`Aplicar ${pendingSql.length} alteracao(oes) pendente(s)?\n\n${preview}${suffix}`)) {
+        return;
+      }
+
+      for (const sql of pendingSql) {
         const payload = await invoke<ExecuteQueryPayload>('execute_query', {
           connId: resolvedConnectionId,
           query: sql,
@@ -1752,10 +1762,25 @@ export default function QueryWorkspace() {
                     ? 'bg-amber-400/12 text-amber-200 hover:bg-amber-400/18'
                     : 'text-muted hover:bg-border/30 hover:text-text'
                 }`}
-                title={t('saveChanges')}
+                title={hasPendingChanges ? `${t('saveChanges')} (${pendingRowEdits.size + pendingNewRows.length})` : t('saveChanges')}
               >
                 <Save size={13} />
               </button>
+              {hasPendingChanges ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPendingRowEdits(new Map());
+                    setPendingNewRows([]);
+                    setSaveError(null);
+                  }}
+                  disabled={loading}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-35"
+                  title="Desfazer alteracoes pendentes"
+                >
+                  <RotateCcw size={13} />
+                </button>
+              ) : null}
             </div>
 
             <div className="hidden lg:flex shrink-0 items-center gap-1.5 rounded-lg border border-border/70 bg-background/18 px-2.5 py-1.5 text-xs text-muted" style={{ fontFamily: 'ui-monospace, monospace' }}>
@@ -1854,6 +1879,7 @@ export default function QueryWorkspace() {
             <label className="flex min-w-[150px] max-w-[260px] flex-1 items-center gap-2 rounded-lg border border-border/70 bg-background/30 px-2.5 py-1.5">
               <Search size={13} className="shrink-0 text-muted" />
               <input
+                ref={quickFilterInputRef}
                 value={quickFilterInput}
                 onChange={(event) => setQuickFilterInput(event.target.value)}
                 placeholder={t('quickFilter')}
@@ -1862,6 +1888,15 @@ export default function QueryWorkspace() {
             </label>
 
             <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
+              <button
+                type="button"
+                onClick={() => setResultsCollapsed(true)}
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-border/30 hover:text-text"
+                title="Fechar grid"
+                aria-label="Fechar grid"
+              >
+                <X size={13} />
+              </button>
               <button
                 type="button"
                 onClick={() => setGridFullscreen((current) => !current)}
@@ -1876,7 +1911,7 @@ export default function QueryWorkspace() {
             <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
               <button
                 onClick={() => {
-                  exportRowsAsCsv(activeResult.columns, filteredRows, buildExportBaseName(connectionLabel));
+                  exportRowsAsCsv(activeResult.columns, filteredRows, buildExportBaseName(connectionLabel, 'filtered'));
                   if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
                   setExportedFormat('csv');
                   exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
@@ -1893,7 +1928,7 @@ export default function QueryWorkspace() {
               </button>
               <button
                 onClick={() => {
-                  exportRowsAsJson(filteredRows, buildExportBaseName(connectionLabel));
+                  exportRowsAsJson(filteredRows, buildExportBaseName(connectionLabel, 'filtered'));
                   if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
                   setExportedFormat('json');
                   exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
@@ -1907,6 +1942,33 @@ export default function QueryWorkspace() {
               >
                 {exportedFormat === 'json' ? <Check size={13} /> : <FileJson size={13} />}
                 JSON
+              </button>
+              <button
+                onClick={() => {
+                  exportRowsAsCsv(activeResult.columns, activeResult.rows, buildExportBaseName(connectionLabel, 'page'));
+                  if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
+                  setExportedFormat('csv');
+                  exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5 text-xs text-muted transition-colors hover:bg-border/30 hover:text-text"
+                title="Exportar pagina atual em CSV"
+              >
+                <Download size={13} />
+                Pagina
+              </button>
+              <button
+                onClick={() => {
+                  const loadedRows = collectLoadedPageRows(activeResult);
+                  exportRowsAsJsonLines(loadedRows, buildExportBaseName(connectionLabel, 'loaded-pages'));
+                  if (exportFeedbackRef.current) window.clearTimeout(exportFeedbackRef.current);
+                  setExportedFormat('json');
+                  exportFeedbackRef.current = window.setTimeout(() => setExportedFormat(null), 1500);
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5 text-xs text-muted transition-colors hover:bg-border/30 hover:text-text"
+                title="Exportar paginas carregadas em JSON Lines"
+              >
+                <FileJson size={13} />
+                JSONL
               </button>
             </div>
 
@@ -2009,6 +2071,8 @@ export default function QueryWorkspace() {
                   rows={filteredRows}
                   rowNumberOffset={quickFilter ? 0 : rowNumberOffset}
                   density={density}
+                  layoutKey={buildGridLayoutKey(resolvedConnectionId, activeResult.statement, activeSourceTable)}
+                  onFocusQuickFilter={() => quickFilterInputRef.current?.focus()}
                   onCellChange={canEditGrid ? handleCellChange : undefined}
                   pendingRowEdits={pendingRowEdits}
                   pendingNewRows={canEditGrid ? pendingNewRows : undefined}
@@ -2406,7 +2470,7 @@ export default function QueryWorkspace() {
             );
           })()}
 
-          {!gridFullscreen ? (
+          {!gridFullscreen && !resultsCollapsed ? (
             <>
               <div
                 role="separator"
@@ -2422,6 +2486,15 @@ export default function QueryWorkspace() {
               </div>
               {renderResultsPanel(false)}
             </>
+          ) : null}
+          {!gridFullscreen && resultsCollapsed ? (
+            <button
+              type="button"
+              onClick={() => setResultsCollapsed(false)}
+              className="absolute bottom-3 right-3 z-20 rounded-lg border border-border bg-surface/95 px-3 py-1.5 text-xs text-muted shadow-lg hover:bg-border/30 hover:text-text"
+            >
+              Mostrar resultados
+            </button>
           ) : null}
         </div>
       </div>
@@ -3198,6 +3271,25 @@ function exportRowsAsJson(rows: any[], baseName: string) {
   downloadTextFile(`${baseName}.json`, JSON.stringify(rows, null, 2), 'application/json;charset=utf-8;');
 }
 
+function exportRowsAsJsonLines(rows: any[], baseName: string) {
+  downloadTextFile(
+    `${baseName}.jsonl`,
+    rows.map((row) => JSON.stringify(row)).join('\n'),
+    'application/x-ndjson;charset=utf-8;',
+  );
+}
+
+function collectLoadedPageRows(result: QueryExecutionResult) {
+  const pages = result.pageCache
+    ? Object.entries(result.pageCache)
+        .map(([page, pageResult]) => [Number(page), pageResult] as const)
+        .sort((a, b) => a[0] - b[0])
+        .map(([, pageResult]) => pageResult.rows)
+    : [result.rows];
+
+  return pages.flat();
+}
+
 function downloadTextFile(filename: string, contents: string, contentType: string) {
   const blob = new Blob([contents], { type: contentType });
   const url = URL.createObjectURL(blob);
@@ -3214,13 +3306,33 @@ function escapeCsvValue(value: unknown) {
   return `"${escaped}"`;
 }
 
-function buildExportBaseName(connectionLabel?: string) {
+function buildExportBaseName(connectionLabel?: string, scope = 'results') {
   const safeConnection = (connectionLabel || 'results')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 
-  return `${safeConnection || 'results'}-${Date.now()}`;
+  return `${safeConnection || 'results'}-${scope}-${Date.now()}`;
+}
+
+function buildGridLayoutKey(
+  connectionId: string | null,
+  statement: string,
+  sourceTable: ReturnType<typeof resolveSimpleSourceTable>,
+) {
+  if (connectionId && sourceTable?.schemaName && sourceTable.tableName) {
+    return `${connectionId}:${sourceTable.schemaName}.${sourceTable.tableName}`;
+  }
+
+  return `query:${hashString(statement.replace(/\s+/g, ' ').trim())}`;
+}
+
+function hashString(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index++) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash).toString(36);
 }
 
 function summarizeStatementForLog(statement: string) {

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -56,6 +56,7 @@ interface QueryResult {
   total_rows?: number | null;
   page?: number | null;
   page_size?: number | null;
+  has_more?: boolean | null;
 }
 
 interface QueryColumnMeta {
@@ -410,13 +411,15 @@ export default function QueryWorkspace() {
     statement: string;
     result: QueryResult;
   }) => {
-    if (!tabId || result.page == null || result.page_size == null || result.total_rows == null) {
+    if (!tabId || result.page == null || result.page_size == null) {
       return;
     }
 
     const nextPage = result.page + 1;
-    const totalPagesForResult = Math.ceil(result.total_rows / Math.max(result.page_size, 1));
-    if (nextPage > totalPagesForResult) {
+    const totalPagesForResult = result.total_rows == null
+      ? null
+      : Math.ceil(result.total_rows / Math.max(result.page_size, 1));
+    if (totalPagesForResult == null ? result.has_more !== true : nextPage > totalPagesForResult) {
       return;
     }
 
@@ -432,7 +435,7 @@ export default function QueryWorkspace() {
         query: statement,
         page: nextPage,
         pageSize: result.page_size,
-        knownTotalRows: result.total_rows,
+        knownTotalRows: result.total_rows ?? undefined,
       });
       appendDiagnostics(connectionId, payload.diagnostics);
 
@@ -901,11 +904,23 @@ export default function QueryWorkspace() {
   const cachedSourceColumns = resolvedConnectionId && activeSourceTable?.schemaName && activeSourceTable.tableName
     ? metadataByConnection[resolvedConnectionId]?.schemasByName[activeSourceTable.schemaName]?.tablesByName[activeSourceTable.tableName]?.columns
     : undefined;
-  const totalRows = activeResult?.total_rows ?? activeResult?.rows.length ?? 0;
+  const totalRowsKnown = activeResult?.total_rows != null;
+  const loadedRows = activeResult?.rows.length ?? 0;
+  const totalRows = activeResult?.total_rows ?? loadedRows;
   const currentPage = activeResult?.page ?? 1;
   const pageSize = activeResult?.page_size ?? resultPageSize;
-  const totalPages = Math.max(1, Math.ceil(totalRows / Math.max(pageSize, 1)));
   const canPaginate = hasGridResult && activeResult?.page != null && activeResult?.page_size != null;
+  const hasMorePages = activeResult?.has_more === true;
+  const totalPages = totalRowsKnown
+    ? Math.max(1, Math.ceil(totalRows / Math.max(pageSize, 1)))
+    : hasMorePages
+      ? currentPage + 1
+      : currentPage;
+  const canLoadNextPage = canPaginate && (totalRowsKnown ? currentPage < totalPages : hasMorePages);
+  const paginationTotalLabel = totalRowsKnown ? String(totalPages) : hasMorePages ? '...' : String(currentPage);
+  const displayedTotalRows = totalRowsKnown
+    ? formatNumber(locale, totalRows)
+    : `${formatNumber(locale, loadedRows)}${hasMorePages ? '+' : ''}`;
   const rowNumberOffset = canPaginate ? (currentPage - 1) * pageSize : 0;
   const selectedDisplayRowIndex =
     selectedSourceRowIndex != null && activeResult
@@ -1434,15 +1449,17 @@ export default function QueryWorkspace() {
                   <span>
                     {formatNumber(locale, filteredRows.length)}
                     {' / '}
-                    {formatNumber(locale, quickFilter ? activeResult.rows.length : totalRows)}
-                    {quickFilter && totalRows !== activeResult.rows.length ? ` / ${formatNumber(locale, totalRows)}` : ''}
+                    {quickFilter ? formatNumber(locale, activeResult.rows.length) : displayedTotalRows}
+                    {quickFilter && (totalRowsKnown ? totalRows !== activeResult.rows.length : hasMorePages)
+                      ? ` / ${displayedTotalRows}`
+                      : ''}
                     {' '}
                     {t('rowsLabel')}
                   </span>
                   {canPaginate ? (
                     <>
                       <span style={{ opacity: 0.4 }}>│</span>
-                      <span>{t('pageOf', { page: currentPage, total: totalPages })}</span>
+                      <span>{t('pageOf', { page: currentPage, total: paginationTotalLabel })}</span>
                     </>
                   ) : null}
                   <span style={{ opacity: 0.4 }}>│</span>
@@ -1498,11 +1515,11 @@ export default function QueryWorkspace() {
                     <ChevronLeft size={14} />
                   </button>
                   <span className="px-1 text-[11px] text-muted">
-                    {currentPage}/{totalPages}
+                    {currentPage}/{paginationTotalLabel}
                   </span>
                   <button
                     onClick={() => void loadResultPage(activeResultIndex, currentPage + 1)}
-                    disabled={loading || currentPage >= totalPages}
+                    disabled={loading || !canLoadNextPage}
                     className="inline-flex items-center rounded-md px-1.5 py-1 text-xs text-muted hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
                     aria-label={t('nextPage')}
                   >

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -1007,6 +1007,8 @@ export default function QueryWorkspace() {
       ? currentPage + 1
       : currentPage;
   const canLoadNextPage = canPaginate && (totalRowsKnown ? currentPage < totalPages : hasMorePages);
+  const nextPageCached = Boolean(canPaginate && activeResult?.pageCache?.[currentPage + 1]);
+  const cachedPageCount = activeResult?.pageCache ? Object.keys(activeResult.pageCache).length : 0;
   const paginationTotalLabel = totalRowsKnown ? String(totalPages) : hasMorePages ? '...' : String(currentPage);
   const displayedTotalRows = totalRowsKnown
     ? formatNumber(locale, totalRows)
@@ -1510,15 +1512,13 @@ export default function QueryWorkspace() {
         </div>
 
         {activeResult && hasGridResult ? (
-          <div className="flex flex-1 items-center min-w-0">
-
-            {/* Container 1 — início: + e salvar */}
-            <div className="flex items-center gap-1 shrink-0">
+          <div className="flex flex-1 items-center gap-2 overflow-x-auto scrollbar-hide min-w-0">
+            <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
               <button
                 type="button"
                 onClick={handleAddNewRow}
                 disabled={!canEditGrid || loading}
-                className="inline-flex items-center rounded-lg border border-border/70 px-2 py-1.5 text-xs text-muted transition-colors hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-35"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-35"
                 title={t('addRow')}
               >
                 <Plus size={13} />
@@ -1527,10 +1527,10 @@ export default function QueryWorkspace() {
                 type="button"
                 onClick={() => void handleSaveChanges()}
                 disabled={!hasPendingChanges || loading}
-                className={`inline-flex items-center rounded-lg border px-2 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-35 ${
+                className={`inline-flex h-7 w-7 items-center justify-center rounded-md text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-35 ${
                   hasPendingChanges
-                    ? 'border-amber-400/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/18'
-                    : 'border-border/70 text-muted hover:bg-border/30 hover:text-text'
+                    ? 'bg-amber-400/12 text-amber-200 hover:bg-amber-400/18'
+                    : 'text-muted hover:bg-border/30 hover:text-text'
                 }`}
                 title={t('saveChanges')}
               >
@@ -1538,110 +1538,122 @@ export default function QueryWorkspace() {
               </button>
             </div>
 
-            {/* Container 2 — centro: stats, transação, paginação, filtro, fullscreen, exports */}
-            <div className="flex flex-1 items-center justify-center gap-2 min-w-0 px-2">
-              <div className="hidden md:flex items-center gap-1.5 text-xs shrink-0" style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--bt-muted)' }}>
-                <>
-                  <span style={{ color: 'var(--bt-muted)' }}>✓</span>
-                  <span>
-                    {formatNumber(locale, filteredRows.length)}
-                    {' / '}
-                    {quickFilter ? formatNumber(locale, activeResult.rows.length) : displayedTotalRows}
-                    {quickFilter && (totalRowsKnown ? totalRows !== activeResult.rows.length : hasMorePages)
-                      ? ` / ${displayedTotalRows}`
-                      : ''}
-                    {' '}
-                    {t('rowsLabel')}
-                  </span>
-                  {canPaginate ? (
-                    <>
-                      <span style={{ opacity: 0.4 }}>│</span>
-                      <span>{t('pageOf', { page: currentPage, total: paginationTotalLabel })}</span>
-                    </>
-                  ) : null}
-                  <span style={{ opacity: 0.4 }}>│</span>
-                </>
-                <span style={{ color: 'var(--bt-muted)' }}>{activeResult.execution_time}ms</span>
-              </div>
-              {transactionOpen ? (
-                <>
-                  <span className="inline-flex items-center rounded-lg border border-sky-400/30 bg-sky-400/10 px-2.5 py-1.5 text-xs text-sky-200">
-                    {t('transactionOpen')}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => void handleTransactionAction('COMMIT')}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-400/35 bg-emerald-400/12 px-2.5 py-1.5 text-xs text-emerald-200 transition-colors hover:bg-emerald-400/18"
-                  >
-                    {t('commitAction')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void handleTransactionAction('ROLLBACK')}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-red-400/25 bg-red-400/10 px-2.5 py-1.5 text-xs text-red-300 transition-colors hover:bg-red-400/16"
-                  >
-                    {t('rollbackAction')}
-                  </button>
-                </>
-              ) : null}
+            <div className="hidden lg:flex shrink-0 items-center gap-1.5 rounded-lg border border-border/70 bg-background/18 px-2.5 py-1.5 text-xs text-muted" style={{ fontFamily: 'ui-monospace, monospace' }}>
+              <Check size={12} className="text-emerald-300/80" />
+              <span>
+                {formatNumber(locale, filteredRows.length)}
+                {' / '}
+                {quickFilter ? formatNumber(locale, activeResult.rows.length) : displayedTotalRows}
+                {quickFilter && (totalRowsKnown ? totalRows !== activeResult.rows.length : hasMorePages)
+                  ? ` / ${displayedTotalRows}`
+                  : ''}
+                {' '}
+                {t('rowsLabel')}
+              </span>
               {canPaginate ? (
-                <div className="flex items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
-                  <label className="inline-flex items-center gap-1 rounded-md px-1 text-[11px] text-muted">
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      value={pageSizeDraft}
-                      onChange={(event) => setPageSizeDraft(event.target.value.replace(/[^0-9]/g, ''))}
-                      onBlur={() => void applyPageSize()}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          event.preventDefault();
-                          void applyPageSize();
-                        }
-                      }}
-                      className="w-14 rounded border border-border/70 bg-background/35 px-1.5 py-1 text-right text-[11px] text-text outline-none focus:border-primary"
-                    />
-                    <span>{t('rowsLabel')}</span>
-                  </label>
-                  <button
-                    onClick={() => void loadResultPage(activeResultIndex, currentPage - 1)}
-                    disabled={loading || currentPage <= 1}
-                    className="inline-flex items-center rounded-md px-1.5 py-1 text-xs text-muted hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
-                    aria-label={t('previousPage')}
-                  >
-                    <ChevronLeft size={14} />
-                  </button>
-                  <span className="px-1 text-[11px] text-muted">
-                    {currentPage}/{paginationTotalLabel}
-                  </span>
-                  <button
-                    onClick={() => void loadResultPage(activeResultIndex, currentPage + 1)}
-                    disabled={loading || !canLoadNextPage}
-                    className="inline-flex items-center rounded-md px-1.5 py-1 text-xs text-muted hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
-                    aria-label={t('nextPage')}
-                  >
-                    <ChevronRight size={14} />
-                  </button>
-                </div>
+                <>
+                  <span className="text-muted/35">|</span>
+                  <span>{t('pageOf', { page: currentPage, total: paginationTotalLabel })}</span>
+                </>
               ) : null}
-              <label className="flex items-center gap-2 rounded-lg border border-border/70 bg-background/30 px-2.5 py-1.5 min-w-[160px] md:min-w-[200px]">
-                <Search size={13} className="shrink-0 text-muted" />
-                <input
-                  value={quickFilterInput}
-                  onChange={(event) => setQuickFilterInput(event.target.value)}
-                  placeholder={t('quickFilter')}
-                  className="w-full bg-transparent text-xs text-text outline-none placeholder:text-muted"
-                />
-              </label>
+              <span className="text-muted/35">|</span>
+              <span>{activeResult.execution_time}ms</span>
+            </div>
+
+            {transactionOpen ? (
+              <div className="flex shrink-0 items-center gap-1 rounded-lg border border-sky-400/25 bg-sky-400/8 px-1.5 py-1">
+                <span className="hidden xl:inline px-1 text-xs text-sky-200">
+                  {t('transactionOpen')}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void handleTransactionAction('COMMIT')}
+                  className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-emerald-200 transition-colors hover:bg-emerald-400/14"
+                >
+                  {t('commitAction')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleTransactionAction('ROLLBACK')}
+                  className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-red-300 transition-colors hover:bg-red-400/14"
+                >
+                  {t('rollbackAction')}
+                </button>
+              </div>
+            ) : null}
+
+            {canPaginate ? (
+              <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
+                <label className="inline-flex items-center gap-1 rounded-md px-1 text-[11px] text-muted">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={pageSizeDraft}
+                    onChange={(event) => setPageSizeDraft(event.target.value.replace(/[^0-9]/g, ''))}
+                    onBlur={() => void applyPageSize()}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        void applyPageSize();
+                      }
+                    }}
+                    className="w-14 rounded border border-border/70 bg-background/35 px-1.5 py-1 text-right text-[11px] text-text outline-none focus:border-primary"
+                  />
+                  <span>{t('rowsLabel')}</span>
+                </label>
+                <button
+                  onClick={() => void loadResultPage(activeResultIndex, currentPage - 1)}
+                  disabled={loading || currentPage <= 1}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+                  aria-label={t('previousPage')}
+                  title={t('previousPage')}
+                >
+                  <ChevronLeft size={14} />
+                </button>
+                <span className="min-w-[52px] text-center text-[11px] text-muted">
+                  {currentPage}/{paginationTotalLabel}
+                </span>
+                <button
+                  onClick={() => void loadResultPage(activeResultIndex, currentPage + 1)}
+                  disabled={loading || !canLoadNextPage}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-border/30 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+                  aria-label={t('nextPage')}
+                  title={t('nextPage')}
+                >
+                  <ChevronRight size={14} />
+                </button>
+                {nextPageCached ? (
+                  <span
+                    className="h-1.5 w-1.5 rounded-full bg-emerald-300/80"
+                    title={`Proxima pagina em cache (${cachedPageCount})`}
+                  />
+                ) : null}
+              </div>
+            ) : null}
+
+            <label className="flex min-w-[150px] max-w-[260px] flex-1 items-center gap-2 rounded-lg border border-border/70 bg-background/30 px-2.5 py-1.5">
+              <Search size={13} className="shrink-0 text-muted" />
+              <input
+                value={quickFilterInput}
+                onChange={(event) => setQuickFilterInput(event.target.value)}
+                placeholder={t('quickFilter')}
+                className="w-full bg-transparent text-xs text-text outline-none placeholder:text-muted"
+              />
+            </label>
+
+            <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
               <button
                 type="button"
                 onClick={() => setGridFullscreen((current) => !current)}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs text-muted transition-colors hover:bg-border/30 hover:text-text"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-border/30 hover:text-text"
                 title={fullscreen ? t('exitFullscreenGrid') : t('maximizeGrid')}
+                aria-label={fullscreen ? t('exitFullscreenGrid') : t('maximizeGrid')}
               >
                 {fullscreen ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
-                {fullscreen ? t('exitFullscreenGrid') : t('maximizeGrid')}
               </button>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border/70 bg-background/24 px-1.5 py-1">
               <button
                 onClick={() => {
                   exportRowsAsCsv(activeResult.columns, filteredRows, buildExportBaseName(connectionLabel));
@@ -1652,8 +1664,9 @@ export default function QueryWorkspace() {
                 className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs transition-colors ${
                   exportedFormat === 'csv'
                     ? 'border-emerald-400/40 bg-emerald-400/12 text-emerald-200'
-                    : 'border-border text-muted hover:bg-border/30 hover:text-text'
+                    : 'border-transparent text-muted hover:bg-border/30 hover:text-text'
                 }`}
+                title="Exportar CSV"
               >
                 {exportedFormat === 'csv' ? <Check size={13} /> : <Download size={13} />}
                 CSV
@@ -1668,27 +1681,27 @@ export default function QueryWorkspace() {
                 className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs transition-colors ${
                   exportedFormat === 'json'
                     ? 'border-emerald-400/40 bg-emerald-400/12 text-emerald-200'
-                    : 'border-border text-muted hover:bg-border/30 hover:text-text'
+                    : 'border-transparent text-muted hover:bg-border/30 hover:text-text'
                 }`}
+                title="Exportar JSON"
               >
                 {exportedFormat === 'json' ? <Check size={13} /> : <FileJson size={13} />}
                 JSON
               </button>
             </div>
 
-            {/* Container 3 — fim: lixeira colada na borda */}
-            <div className="shrink-0">
+            <div className="ml-auto shrink-0">
               <button
                 type="button"
                 onClick={() => void handleDeleteSelectedRow()}
                 disabled={selectedSourceRowIndex == null || loading}
-                className="inline-flex items-center rounded-lg border border-red-400/25 px-2 py-1.5 text-xs text-red-300/70 transition-colors hover:bg-red-400/10 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-35"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red-400/25 text-red-300/70 transition-colors hover:bg-red-400/10 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-35"
                 title={t('deleteSelectedRow')}
+                aria-label={t('deleteSelectedRow')}
               >
                 <Trash2 size={13} />
               </button>
             </div>
-
           </div>
         ) : activeResult ? (
           <div className="flex flex-1 items-center justify-end gap-2 min-w-0">

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -86,6 +86,12 @@ interface ExecuteQueryPayload {
   diagnostics?: string[];
 }
 
+interface CountQueryPayload {
+  total_rows: number;
+  execution_time: number;
+  diagnostics?: string[];
+}
+
 const SEMANTIC_SUCCESS_DURATION_MS = 3600;
 const SEMANTIC_ERROR_DURATION_MS = 6200;
 const SEMANTIC_WARNING_DURATION_MS = 6200;
@@ -215,6 +221,7 @@ export default function QueryWorkspace() {
   const suggestTimeoutRef = useRef<number | null>(null);
   const semanticResetTimeoutRef = useRef<number | null>(null);
   const pagePrefetchKeysRef = useRef<Set<string>>(new Set());
+  const countQueryKeysRef = useRef<Set<string>>(new Set());
   const autocompleteContextRef = useRef<{
     connectionId?: string | null;
     activeSchema?: string | null;
@@ -398,6 +405,73 @@ export default function QueryWorkspace() {
     diagnostics?.forEach((entry) => appendLog(connectionId, entry));
   }, [appendLog]);
 
+  const countResultRows = useCallback(async ({
+    tabId,
+    resultIndex,
+    connectionId,
+    statement,
+    result,
+  }: {
+    tabId: string | null | undefined;
+    resultIndex: number;
+    connectionId: string;
+    statement: string;
+    result: QueryResult;
+  }) => {
+    if (!tabId || result.page == null || result.page_size == null || result.total_rows != null) {
+      return;
+    }
+
+    const key = `${tabId}:${resultIndex}:${statement}`;
+    if (countQueryKeysRef.current.has(key)) {
+      return;
+    }
+
+    countQueryKeysRef.current.add(key);
+    try {
+      const payload = await invoke<CountQueryPayload>('count_query', {
+        connId: connectionId,
+        query: statement,
+      });
+      appendDiagnostics(connectionId, payload.diagnostics);
+
+      setTabResults(tabId, (current) =>
+        current.map((item, index) => {
+          if (index !== resultIndex || item.statement !== statement) {
+            return item;
+          }
+
+          const totalRows = payload.total_rows;
+          const updatePage = (pageResult: QueryResult): QueryResult => ({
+            ...pageResult,
+            total_rows: totalRows,
+            has_more: pageResult.page != null && pageResult.page_size != null
+              ? pageResult.page * pageResult.page_size < totalRows
+              : pageResult.has_more,
+          });
+          const nextPageCache: Record<number, QueryResult> | undefined = item.pageCache
+            ? Object.fromEntries(
+                Object.entries(item.pageCache).map(([page, pageResult]) => [Number(page), updatePage(pageResult)]),
+              )
+            : item.pageCache;
+
+          return {
+            ...item,
+            total_rows: totalRows,
+            has_more: item.page != null && item.page_size != null
+              ? item.page * item.page_size < totalRows
+              : item.has_more,
+            pageCache: nextPageCache,
+          };
+        }),
+      );
+    } catch (error) {
+      appendLog(connectionId, `Erro ao contar linhas em background: ${extractErrorMessage(error).trim()}`);
+    } finally {
+      countQueryKeysRef.current.delete(key);
+    }
+  }, [appendDiagnostics, appendLog, setTabResults]);
+
   const prefetchNextResultPage = useCallback(async ({
     tabId,
     resultIndex,
@@ -525,6 +599,15 @@ export default function QueryWorkspace() {
 
       setTabResults(targetTabId, nextResults);
       setTabActiveResultIndex(targetTabId, 0);
+      nextResults.forEach((result, index) => {
+        void countResultRows({
+          tabId: targetTabId,
+          resultIndex: index,
+          connectionId,
+          statement: result.statement,
+          result,
+        });
+      });
       await waitForMinimumRunning(runningStartedAt);
       setSemanticBackgroundState('success');
       scheduleSemanticReset(SEMANTIC_SUCCESS_DURATION_MS);
@@ -544,7 +627,7 @@ export default function QueryWorkspace() {
     } finally {
       setLoading(false);
     }
-  }, [activeSchemaByConnection, activeTabId, appendDiagnostics, appendLog, connections, metadataByConnection, prefetchNextResultPage, resultPageSize, scheduleSemanticReset, setSemanticBackgroundState, setTabActiveResultIndex, setTabError, setTabResults, startExecutionFeedback]);
+  }, [activeSchemaByConnection, activeTabId, appendDiagnostics, appendLog, connections, countResultRows, metadataByConnection, prefetchNextResultPage, resultPageSize, scheduleSemanticReset, setSemanticBackgroundState, setTabActiveResultIndex, setTabError, setTabResults, startExecutionFeedback]);
 
   const ensureExecutionConnectionReady = useCallback(async (connectionId: string) => {
     const connection = connections.find((item) => item.id === connectionId);
@@ -806,6 +889,13 @@ export default function QueryWorkspace() {
         statement: targetResult.statement,
         result: payload.result,
       });
+      void countResultRows({
+        tabId: targetTabId,
+        resultIndex,
+        connectionId: resolvedConnectionId,
+        statement: targetResult.statement,
+        result: payload.result,
+      });
     } catch (pageError) {
       appendLog(resolvedConnectionId, `Erro ao carregar pagina: ${extractErrorMessage(pageError).trim()}`);
       setTabError(
@@ -821,7 +911,7 @@ export default function QueryWorkspace() {
     } finally {
       setLoading(false);
     }
-  }, [activeTabId, appendDiagnostics, appendLog, ensureExecutionConnectionReady, engine, metadataByConnection, prefetchNextResultPage, resolvedConnectionId, resultPageSize, results, schemaLabel, setTabActiveResultIndex, setTabError, setTabResults]);
+  }, [activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, prefetchNextResultPage, resolvedConnectionId, resultPageSize, results, schemaLabel, setTabActiveResultIndex, setTabError, setTabResults]);
 
   useEffect(() => {
     setPageSizeDraft(String(resultPageSize));
@@ -1016,6 +1106,13 @@ export default function QueryWorkspace() {
             : item,
         ),
       );
+      void countResultRows({
+        tabId: targetTabId,
+        resultIndex: activeResultIndex,
+        connectionId: resolvedConnectionId,
+        statement: activeResult.statement,
+        result: payload.result,
+      });
     } catch (pageSizeError) {
       appendLog(resolvedConnectionId, `Erro ao aplicar limite de linhas: ${extractErrorMessage(pageSizeError).trim()}`);
       setTabError(
@@ -1031,7 +1128,7 @@ export default function QueryWorkspace() {
     } finally {
       setLoading(false);
     }
-  }, [activeResult, activeResultIndex, activeTabId, appendDiagnostics, appendLog, ensureExecutionConnectionReady, engine, metadataByConnection, pageSizeDraft, resolvedConnectionId, resultPageSize, schemaLabel, setResultPageSize, setTabError, setTabResults]);
+  }, [activeResult, activeResultIndex, activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, pageSizeDraft, resolvedConnectionId, resultPageSize, schemaLabel, setResultPageSize, setTabError, setTabResults]);
 
   const handleCellChange = useCallback((
     colName: string,

--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -11,11 +11,12 @@ import { invoke } from '@tauri-apps/api/core';
 import { createPortal, flushSync } from 'react-dom';
 import { ensureColumnsCached, ensureTablesCached, warmMetadataAfterConnect } from '../database/metadata-cache';
 import { useDatabaseSessionStore } from '../../store/databaseSession';
-import type { MetadataColumn } from '../database/types';
+import type { MetadataColumn, MetadataConnectionEntry } from '../database/types';
 import {
   Plus,
   X,
   Play,
+  Square,
   Clock3,
   AlignLeft,
   Sparkles,
@@ -76,6 +77,8 @@ interface QueryExecutionResult extends QueryResult {
   statement: string;
   title: string;
   pageCache?: Record<number, QueryResult>;
+  paginationStrategy?: 'offset' | 'keyset';
+  keysetCursors?: Record<number, unknown>;
 }
 
 interface ExecuteQueryPayload {
@@ -90,6 +93,12 @@ interface CountQueryPayload {
   total_rows: number;
   execution_time: number;
   diagnostics?: string[];
+}
+
+interface PageCacheBucket {
+  pages: Record<number, QueryResult>;
+  touchedAt: number;
+  totalRows?: number | null;
 }
 
 const SEMANTIC_SUCCESS_DURATION_MS = 3600;
@@ -222,6 +231,11 @@ export default function QueryWorkspace() {
   const semanticResetTimeoutRef = useRef<number | null>(null);
   const pagePrefetchKeysRef = useRef<Set<string>>(new Set());
   const countQueryKeysRef = useRef<Set<string>>(new Set());
+  const pageCacheRef = useRef<Map<string, PageCacheBucket>>(new Map());
+  const executionSeqRef = useRef(0);
+  const currentExecutionIdRef = useRef<string | null>(null);
+  const cancelledExecutionIdsRef = useRef<Set<string>>(new Set());
+  const [activeExecutionId, setActiveExecutionId] = useState<string | null>(null);
   const autocompleteContextRef = useRef<{
     connectionId?: string | null;
     activeSchema?: string | null;
@@ -387,6 +401,12 @@ export default function QueryWorkspace() {
       semanticResetTimeoutRef.current = null;
     }
 
+    const executionId = `exec-${Date.now()}-${executionSeqRef.current + 1}`;
+    executionSeqRef.current += 1;
+    currentExecutionIdRef.current = executionId;
+    cancelledExecutionIdsRef.current.delete(executionId);
+    setActiveExecutionId(executionId);
+
     flushSync(() => {
       setSemanticBackgroundState('running');
       setLoading(true);
@@ -404,6 +424,80 @@ export default function QueryWorkspace() {
   const appendDiagnostics = useCallback((connectionId: string, diagnostics?: string[]) => {
     diagnostics?.forEach((entry) => appendLog(connectionId, entry));
   }, [appendLog]);
+
+  const isExecutionCancelled = useCallback((executionId: string | null) => (
+    executionId != null && cancelledExecutionIdsRef.current.has(executionId)
+  ), []);
+
+  const finishExecution = useCallback((executionId: string | null) => {
+    if (executionId && currentExecutionIdRef.current !== executionId) {
+      return;
+    }
+
+    currentExecutionIdRef.current = null;
+    setActiveExecutionId(null);
+    setLoading(false);
+  }, []);
+
+  const cancelActiveExecution = useCallback(() => {
+    const executionId = currentExecutionIdRef.current ?? activeExecutionId;
+    if (!executionId) {
+      return;
+    }
+
+    cancelledExecutionIdsRef.current.add(executionId);
+    void invoke('cancel_query', { executionId }).catch(() => null);
+    setSemanticBackgroundState('idle');
+    finishExecution(executionId);
+
+    if (resolvedConnectionId) {
+      appendLog(resolvedConnectionId, `${t('cancelled')}: ${executionId}`);
+    }
+  }, [activeExecutionId, appendLog, finishExecution, resolvedConnectionId, setSemanticBackgroundState, t]);
+
+  const readCachedPage = useCallback((
+    connectionId: string,
+    statement: string,
+    pageSize: number,
+    page: number,
+  ) => {
+    const key = buildResultPageCacheKey(connectionId, statement, pageSize);
+    const bucket = pageCacheRef.current.get(key);
+    if (!bucket) {
+      return null;
+    }
+
+    bucket.touchedAt = Date.now();
+    return bucket.pages[page] ?? null;
+  }, []);
+
+  const writeCachedPage = useCallback((
+    connectionId: string,
+    statement: string,
+    pageSize: number,
+    page: number,
+    result: QueryResult,
+  ) => {
+    const key = buildResultPageCacheKey(connectionId, statement, pageSize);
+    const current = pageCacheRef.current.get(key);
+    pageCacheRef.current.set(key, {
+      pages: {
+        ...(current?.pages ?? {}),
+        [page]: result,
+      },
+      touchedAt: Date.now(),
+      totalRows: result.total_rows ?? current?.totalRows ?? null,
+    });
+    pruneResultPageCache(pageCacheRef.current);
+  }, []);
+
+  const invalidatePageCacheForConnection = useCallback((connectionId: string) => {
+    for (const key of pageCacheRef.current.keys()) {
+      if (key.startsWith(`${connectionId}\u0000`)) {
+        pageCacheRef.current.delete(key);
+      }
+    }
+  }, []);
 
   const countResultRows = useCallback(async ({
     tabId,
@@ -434,6 +528,32 @@ export default function QueryWorkspace() {
         query: statement,
       });
       appendDiagnostics(connectionId, payload.diagnostics);
+      const cacheKey = result.page_size != null
+        ? buildResultPageCacheKey(connectionId, statement, result.page_size)
+        : null;
+      if (cacheKey) {
+        const bucket = pageCacheRef.current.get(cacheKey);
+        if (bucket) {
+          const totalRows = payload.total_rows;
+          pageCacheRef.current.set(cacheKey, {
+            ...bucket,
+            touchedAt: Date.now(),
+            totalRows,
+            pages: Object.fromEntries(
+              Object.entries(bucket.pages).map(([page, pageResult]) => [
+                Number(page),
+                {
+                  ...pageResult,
+                  total_rows: totalRows,
+                  has_more: pageResult.page != null && pageResult.page_size != null
+                    ? pageResult.page * pageResult.page_size < totalRows
+                    : pageResult.has_more,
+                },
+              ]),
+            ),
+          });
+        }
+      }
 
       setTabResults(tabId, (current) =>
         current.map((item, index) => {
@@ -497,6 +617,26 @@ export default function QueryWorkspace() {
       return;
     }
 
+    const cachedPage = readCachedPage(connectionId, statement, result.page_size, nextPage);
+    if (cachedPage) {
+      setTabResults(tabId, (current) =>
+        current.map((item, index) => {
+          if (index !== resultIndex || item.statement !== statement) {
+            return item;
+          }
+
+          return {
+            ...item,
+            pageCache: {
+              ...(item.pageCache ?? {}),
+              [nextPage]: cachedPage,
+            },
+          };
+        }),
+      );
+      return;
+    }
+
     const key = `${tabId}:${resultIndex}:${nextPage}:${statement}`;
     if (pagePrefetchKeysRef.current.has(key)) {
       return;
@@ -512,6 +652,7 @@ export default function QueryWorkspace() {
         knownTotalRows: result.total_rows ?? undefined,
       });
       appendDiagnostics(connectionId, payload.diagnostics);
+      writeCachedPage(connectionId, statement, result.page_size, nextPage, payload.result);
 
       setTabResults(tabId, (current) =>
         current.map((item, index) => {
@@ -533,7 +674,7 @@ export default function QueryWorkspace() {
     } finally {
       pagePrefetchKeysRef.current.delete(key);
     }
-  }, [appendDiagnostics, appendLog, setTabResults]);
+  }, [appendDiagnostics, appendLog, readCachedPage, setTabResults, writeCachedPage]);
 
   const runQueryBatch = useCallback(async (queries: string[], connectionId: string, options?: { feedbackStartedAt?: number; tabId?: string | null }) => {
     const statements = queries.map((item) => item.trim()).filter(Boolean);
@@ -550,6 +691,7 @@ export default function QueryWorkspace() {
     const targetTabId = options?.tabId ?? activeTabId;
     
     const runningStartedAt = options?.feedbackStartedAt ?? startExecutionFeedback();
+    const executionId = currentExecutionIdRef.current;
     if (!options?.feedbackStartedAt) {
       await waitForNextPaint();
     }
@@ -565,14 +707,30 @@ export default function QueryWorkspace() {
           page: 1,
           pageSize: resultPageSize,
         });
+        if (isExecutionCancelled(executionId)) {
+          return;
+        }
         syncTransactionState(connectionId, payload);
         appendDiagnostics(connectionId, payload.diagnostics);
+
+        if (payload.result.page && payload.result.page_size) {
+          writeCachedPage(connectionId, statement, payload.result.page_size, payload.result.page, payload.result);
+        }
+        if (isMutatingStatement(statement)) {
+          invalidatePageCacheForConnection(connectionId);
+        }
+
+        const sourceTable = resolveSimpleSourceTable(statement, targetSchema ?? null);
+        const paginationStrategy = isSimpleTableSelectAll(statement) && resolveKeysetPaginationStrategy(sourceTable, metadataByConnection[connectionId], targetEngine) ? 'keyset' : 'offset';
+        const keysetCursors = buildKeysetCursors(payload.result, paginationStrategy, sourceTable, metadataByConnection[connectionId], targetEngine);
 
         nextResults.push({
           ...payload.result,
           statement,
           title: `Result ${index + 1}`,
           pageCache: payload.result.page ? { [payload.result.page]: payload.result } : undefined,
+          paginationStrategy,
+          keysetCursors,
         });
 
         void prefetchNextResultPage({
@@ -588,13 +746,16 @@ export default function QueryWorkspace() {
           `Query executada com sucesso (${payload.result.execution_time}ms): ${summarizeStatementForLog(statement)}`,
         );
 
-        const sourceTable = resolveSimpleSourceTable(statement, targetSchema ?? null);
         if (sourceTable?.tableName && targetEngine) {
           const schemaForFetch = sourceTable.schemaName ?? targetSchema ?? null;
           if (schemaForFetch) {
             void ensureColumnsCached(connectionId, targetEngine, schemaForFetch, sourceTable.tableName, { priority: true }).catch(() => null);
           }
         }
+      }
+
+      if (isExecutionCancelled(executionId)) {
+        return;
       }
 
       setTabResults(targetTabId, nextResults);
@@ -609,9 +770,15 @@ export default function QueryWorkspace() {
         });
       });
       await waitForMinimumRunning(runningStartedAt);
+      if (isExecutionCancelled(executionId)) {
+        return;
+      }
       setSemanticBackgroundState('success');
       scheduleSemanticReset(SEMANTIC_SUCCESS_DURATION_MS);
     } catch (e: any) {
+      if (isExecutionCancelled(executionId)) {
+        return;
+      }
       const nextError = buildQueryErrorPresentation({
         error: e,
         engine: targetEngine,
@@ -625,9 +792,9 @@ export default function QueryWorkspace() {
       setSemanticBackgroundState('error');
       scheduleSemanticReset(SEMANTIC_ERROR_DURATION_MS);
     } finally {
-      setLoading(false);
+      finishExecution(executionId);
     }
-  }, [activeSchemaByConnection, activeTabId, appendDiagnostics, appendLog, connections, countResultRows, metadataByConnection, prefetchNextResultPage, resultPageSize, scheduleSemanticReset, setSemanticBackgroundState, setTabActiveResultIndex, setTabError, setTabResults, startExecutionFeedback]);
+  }, [activeSchemaByConnection, activeTabId, appendDiagnostics, appendLog, connections, countResultRows, finishExecution, invalidatePageCacheForConnection, isExecutionCancelled, metadataByConnection, prefetchNextResultPage, resultPageSize, scheduleSemanticReset, setSemanticBackgroundState, setTabActiveResultIndex, setTabError, setTabResults, startExecutionFeedback, writeCachedPage]);
 
   const ensureExecutionConnectionReady = useCallback(async (connectionId: string) => {
     const connection = connections.find((item) => item.id === connectionId);
@@ -668,12 +835,17 @@ export default function QueryWorkspace() {
     }
 
     const runningStartedAt = startExecutionFeedback();
+    const executionId = currentExecutionIdRef.current;
     await waitForNextPaint();
 
     try {
       await ensureExecutionConnectionReady(resolvedConnectionId);
       await runQueryBatch(statements, resolvedConnectionId, { feedbackStartedAt: runningStartedAt, tabId: activeTabId });
     } catch (executionError) {
+      if (isExecutionCancelled(executionId)) {
+        finishExecution(executionId);
+        return;
+      }
       const connection = connections.find((item) => item.id === resolvedConnectionId) ?? null;
       appendLog(resolvedConnectionId, `Erro de query: ${extractErrorMessage(executionError).trim()}`);
       setTabError(
@@ -689,7 +861,7 @@ export default function QueryWorkspace() {
       await waitForMinimumRunning(runningStartedAt);
       setSemanticBackgroundState('error');
       scheduleSemanticReset(SEMANTIC_ERROR_DURATION_MS);
-      setLoading(false);
+      finishExecution(executionId);
     }
   }, [
     activeSchemaByConnection,
@@ -698,6 +870,8 @@ export default function QueryWorkspace() {
     connections,
     engine,
     ensureExecutionConnectionReady,
+    finishExecution,
+    isExecutionCancelled,
     metadataByConnection,
     resolvedConnectionId,
     runQueryBatch,
@@ -749,12 +923,17 @@ export default function QueryWorkspace() {
       : addTabWithContent(item.queryText, deriveHistoryTabTitle(item.queryText), item.connectionId);
 
     const runningStartedAt = startExecutionFeedback();
+    const executionId = currentExecutionIdRef.current;
     await waitForNextPaint();
 
     try {
       await ensureExecutionConnectionReady(connection.id);
       await runQueryBatch(splitSqlStatements(item.queryText), connection.id, { feedbackStartedAt: runningStartedAt, tabId: targetTabId });
     } catch (runError) {
+      if (isExecutionCancelled(executionId)) {
+        finishExecution(executionId);
+        return;
+      }
       setTabError(
         targetTabId,
         buildQueryErrorPresentation({
@@ -767,13 +946,15 @@ export default function QueryWorkspace() {
       await waitForMinimumRunning(runningStartedAt);
       setSemanticBackgroundState('error');
       scheduleSemanticReset(SEMANTIC_ERROR_DURATION_MS);
-      setLoading(false);
+      finishExecution(executionId);
     }
   }, [
     addTabWithContent,
     activeTabId,
     connections,
     ensureExecutionConnectionReady,
+    finishExecution,
+    isExecutionCancelled,
     replaceActiveTabContent,
     runQueryBatch,
     scheduleSemanticReset,
@@ -825,7 +1006,9 @@ export default function QueryWorkspace() {
       return;
     }
     const targetTabId = activeTabId;
-    const cachedPage = targetResult.pageCache?.[nextPage];
+    const effectivePageSize = targetResult.page_size ?? resultPageSize;
+    const cachedPage = targetResult.pageCache?.[nextPage]
+      ?? readCachedPage(resolvedConnectionId, targetResult.statement, effectivePageSize, nextPage);
     if (cachedPage) {
       setTabResults(targetTabId, (current) =>
         current.map((item, index) =>
@@ -850,6 +1033,19 @@ export default function QueryWorkspace() {
       return;
     }
 
+    const sourceTable = resolveSimpleSourceTable(targetResult.statement, schemaLabel);
+    const keysetQuery = buildKeysetPageQuery({
+      statement: targetResult.statement,
+      sourceTable,
+      metadata: resolvedConnectionId ? metadataByConnection[resolvedConnectionId] : undefined,
+      engine,
+      nextPage,
+      currentPage: targetResult.page ?? 1,
+      cursor: targetResult.keysetCursors?.[targetResult.page ?? 1],
+    });
+    const executedStatement = keysetQuery ?? targetResult.statement;
+    const requestedBackendPage = keysetQuery ? 1 : nextPage;
+
     setLoading(true);
     setTabError(targetTabId, null);
 
@@ -857,26 +1053,41 @@ export default function QueryWorkspace() {
       await ensureExecutionConnectionReady(resolvedConnectionId);
       const payload = await invoke<ExecuteQueryPayload>('execute_query', {
         connId: resolvedConnectionId,
-        query: targetResult.statement,
-        page: nextPage,
-        pageSize: targetResult.page_size ?? resultPageSize,
+        query: executedStatement,
+        page: requestedBackendPage,
+        pageSize: effectivePageSize,
         // Pass the already-known total so the backend skips an extra COUNT(*) query.
         knownTotalRows: targetResult.total_rows ?? undefined,
       });
       syncTransactionState(resolvedConnectionId, payload);
       appendDiagnostics(resolvedConnectionId, payload.diagnostics);
+      const pageResult = keysetQuery
+        ? {
+            ...payload.result,
+            page: nextPage,
+            page_size: effectivePageSize,
+            total_rows: targetResult.total_rows ?? payload.result.total_rows,
+          }
+        : payload.result;
+      writeCachedPage(resolvedConnectionId, targetResult.statement, effectivePageSize, nextPage, pageResult);
+      const nextKeysetCursors = {
+        ...(targetResult.keysetCursors ?? {}),
+        ...buildKeysetCursors(pageResult, keysetQuery ? 'keyset' : targetResult.paginationStrategy ?? 'offset', sourceTable, resolvedConnectionId ? metadataByConnection[resolvedConnectionId] : undefined, engine),
+      };
 
       setTabResults(targetTabId, (current) =>
         current.map((item, index) =>
           index === resultIndex
             ? {
-                ...payload.result,
+                ...pageResult,
                 statement: item.statement,
                 title: item.title,
                 pageCache: {
                   ...(item.pageCache ?? {}),
-                  [nextPage]: payload.result,
+                  [nextPage]: pageResult,
                 },
+                paginationStrategy: keysetQuery ? 'keyset' : item.paginationStrategy,
+                keysetCursors: nextKeysetCursors,
               }
             : item,
         ),
@@ -887,15 +1098,17 @@ export default function QueryWorkspace() {
         resultIndex,
         connectionId: resolvedConnectionId,
         statement: targetResult.statement,
-        result: payload.result,
+        result: pageResult,
       });
-      void countResultRows({
-        tabId: targetTabId,
-        resultIndex,
-        connectionId: resolvedConnectionId,
-        statement: targetResult.statement,
-        result: payload.result,
-      });
+      if (!keysetQuery) {
+        void countResultRows({
+          tabId: targetTabId,
+          resultIndex,
+          connectionId: resolvedConnectionId,
+          statement: targetResult.statement,
+          result: pageResult,
+        });
+      }
     } catch (pageError) {
       appendLog(resolvedConnectionId, `Erro ao carregar pagina: ${extractErrorMessage(pageError).trim()}`);
       setTabError(
@@ -911,7 +1124,7 @@ export default function QueryWorkspace() {
     } finally {
       setLoading(false);
     }
-  }, [activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, prefetchNextResultPage, resolvedConnectionId, resultPageSize, results, schemaLabel, setTabActiveResultIndex, setTabError, setTabResults]);
+  }, [activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, prefetchNextResultPage, readCachedPage, resolvedConnectionId, resultPageSize, results, schemaLabel, setTabActiveResultIndex, setTabError, setTabResults, writeCachedPage]);
 
   useEffect(() => {
     setPageSizeDraft(String(resultPageSize));
@@ -1095,6 +1308,9 @@ export default function QueryWorkspace() {
       });
       syncTransactionState(resolvedConnectionId, payload);
       appendDiagnostics(resolvedConnectionId, payload.diagnostics);
+      if (payload.result.page && payload.result.page_size) {
+        writeCachedPage(resolvedConnectionId, activeResult.statement, payload.result.page_size, payload.result.page, payload.result);
+      }
 
       setTabResults(targetTabId, (current) =>
         current.map((item, index) =>
@@ -1130,7 +1346,7 @@ export default function QueryWorkspace() {
     } finally {
       setLoading(false);
     }
-  }, [activeResult, activeResultIndex, activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, pageSizeDraft, resolvedConnectionId, resultPageSize, schemaLabel, setResultPageSize, setTabError, setTabResults]);
+  }, [activeResult, activeResultIndex, activeTabId, appendDiagnostics, appendLog, countResultRows, ensureExecutionConnectionReady, engine, metadataByConnection, pageSizeDraft, resolvedConnectionId, resultPageSize, schemaLabel, setResultPageSize, setTabError, setTabResults, writeCachedPage]);
 
   const handleCellChange = useCallback((
     colName: string,
@@ -1221,6 +1437,7 @@ export default function QueryWorkspace() {
 
       setPendingRowEdits(new Map());
       setPendingNewRows([]);
+      invalidatePageCacheForConnection(resolvedConnectionId);
       setHistoryRefreshToken((current) => current + 1);
     } catch (err: any) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1248,6 +1465,7 @@ export default function QueryWorkspace() {
     ensureExecutionConnectionReady,
     syncTransactionState,
     setTabResults,
+    invalidatePageCacheForConnection,
   ]);
 
   const handleRowSelect = useCallback((_rowIndex: number, row: Record<string, unknown>) => {
@@ -1307,6 +1525,7 @@ export default function QueryWorkspace() {
       });
       syncTransactionState(resolvedConnectionId, payload);
       appendDiagnostics(resolvedConnectionId, payload.diagnostics);
+      invalidatePageCacheForConnection(resolvedConnectionId);
 
       setHistoryRefreshToken((current) => current + 1);
       setTabResults(targetTabId, (current) =>
@@ -1347,6 +1566,7 @@ export default function QueryWorkspace() {
     resolvedConnectionId,
     selectedSourceRowIndex,
     setTabResults,
+    invalidatePageCacheForConnection,
   ]);
 
   const handleTransactionAction = useCallback(async (action: 'COMMIT' | 'ROLLBACK') => {
@@ -1920,10 +2140,16 @@ export default function QueryWorkspace() {
               }}
             >
               <button
-                onClick={() => void executeQuery()}
-                disabled={loading || !activeTab || !resolvedConnectionId}
+                onClick={() => {
+                  if (loading && activeExecutionId) {
+                    cancelActiveExecution();
+                    return;
+                  }
+                  void executeQuery();
+                }}
+                disabled={(loading && !activeExecutionId) || (!loading && (!activeTab || !resolvedConnectionId))}
                 className={`flex items-center gap-2 rounded-lg px-4 py-1.5 text-sm font-bold transition-all ${
-                  loading ? 'cursor-default opacity-100' : 'disabled:cursor-not-allowed disabled:opacity-40'
+                  loading && activeExecutionId ? 'cursor-pointer opacity-100' : 'disabled:cursor-not-allowed disabled:opacity-40'
                 }`}
                 style={{
                   background: connectionColor,
@@ -1934,10 +2160,10 @@ export default function QueryWorkspace() {
                 }}
               >
                 {loading
-                  ? <PulseLoader color="#041014" size="xs" surface="transparent" />
+                  ? <Square size={13} style={{ fill: '#041014', color: '#041014', opacity: 0.82 }} />
                   : <Play size={14} style={{ fill: '#041014', color: '#041014', opacity: 0.82 }} />
                 }
-                {loading ? t('statusRunning') : t('run')}
+                {loading ? (activeExecutionId ? t('cancelExecution') : t('statusRunning')) : t('run')}
                 <span style={{ opacity: 0.5, fontFamily: 'ui-monospace, monospace', fontSize: 10 }}>⌘↵</span>
               </button>
 
@@ -2562,6 +2788,16 @@ function isUpdateWithoutWhere(sql: string) {
   return normalized.startsWith('UPDATE ') && !normalized.includes(' WHERE ');
 }
 
+function isMutatingStatement(sql: string) {
+  const normalized = stripSqlCommentsAndStrings(sql).replace(/\s+/g, ' ').trim().toUpperCase();
+  return /^(INSERT|UPDATE|DELETE|MERGE|TRUNCATE|ALTER|DROP|CREATE|REPLACE)\b/.test(normalized);
+}
+
+function isSimpleTableSelectAll(sql: string) {
+  const normalized = stripSqlCommentsAndStrings(sql).replace(/\s+/g, ' ').trim();
+  return /^SELECT\s+\*\s+FROM\s+(?:"[^"]+"|`[^`]+`|[a-zA-Z0-9_$#]+)(?:\.(?:"[^"]+"|`[^`]+`|[a-zA-Z0-9_$#]+))?$/i.test(normalized);
+}
+
 function stripSqlCommentsAndStrings(sql: string) {
   let result = '';
   let inSingleQuote = false;
@@ -2824,6 +3060,129 @@ function applyQuickFilter(rows: any[], columns: string[], quickFilter: string) {
   return rows.filter((row) =>
     columns.some((column) => String(row?.[column] ?? '').toLowerCase().includes(normalizedFilter)),
   );
+}
+
+function buildResultPageCacheKey(connectionId: string, statement: string, pageSize: number) {
+  return [
+    connectionId,
+    normalizeSqlForCache(statement),
+    String(pageSize),
+  ].join('\u0000');
+}
+
+function normalizeSqlForCache(statement: string) {
+  return statement.replace(/\s+/g, ' ').trim();
+}
+
+function pruneResultPageCache(cache: Map<string, PageCacheBucket>) {
+  const maxBuckets = 24;
+  const maxPages = 96;
+  const maxRows = 60_000;
+
+  let pageCount = 0;
+  let rowCount = 0;
+  for (const bucket of cache.values()) {
+    const pages = Object.values(bucket.pages);
+    pageCount += pages.length;
+    rowCount += pages.reduce((total, page) => total + page.rows.length, 0);
+  }
+
+  if (cache.size <= maxBuckets && pageCount <= maxPages && rowCount <= maxRows) {
+    return;
+  }
+
+  const entries = [...cache.entries()].sort((a, b) => a[1].touchedAt - b[1].touchedAt);
+  for (const [key, bucket] of entries) {
+    cache.delete(key);
+    pageCount -= Object.keys(bucket.pages).length;
+    rowCount -= Object.values(bucket.pages).reduce((total, page) => total + page.rows.length, 0);
+
+    if (cache.size <= maxBuckets && pageCount <= maxPages && rowCount <= maxRows) {
+      break;
+    }
+  }
+}
+
+function resolveKeysetPaginationStrategy(
+  sourceTable: ReturnType<typeof resolveSimpleSourceTable>,
+  metadataConnection: MetadataConnectionEntry | undefined,
+  engine: DatabaseEngine | undefined,
+) {
+  if (!sourceTable?.schemaName || !sourceTable.tableName || !metadataConnection || !engine) {
+    return null;
+  }
+
+  const table = metadataConnection.schemasByName[sourceTable.schemaName]?.tablesByName[sourceTable.tableName];
+  const primaryKeys = table?.columns?.filter((column) => column.isPrimaryKey === true) ?? [];
+  if (primaryKeys.length !== 1) {
+    return null;
+  }
+
+  return {
+    pkColumn: primaryKeys[0],
+  };
+}
+
+function buildKeysetCursors(
+  result: QueryResult,
+  strategy: 'offset' | 'keyset',
+  sourceTable: ReturnType<typeof resolveSimpleSourceTable>,
+  metadataConnection: MetadataConnectionEntry | undefined,
+  engine: DatabaseEngine | undefined,
+) {
+  if (strategy !== 'keyset' || result.page == null || !result.rows.length) {
+    return undefined;
+  }
+
+  const resolved = resolveKeysetPaginationStrategy(sourceTable, metadataConnection, engine);
+  if (!resolved) {
+    return undefined;
+  }
+
+  const lastRow = result.rows[result.rows.length - 1] as Record<string, unknown>;
+  return {
+    [result.page]: lastRow[resolved.pkColumn.columnName],
+  };
+}
+
+function buildKeysetPageQuery({
+  statement,
+  sourceTable,
+  metadata,
+  engine,
+  nextPage,
+  currentPage,
+  cursor,
+}: {
+  statement: string;
+  sourceTable: ReturnType<typeof resolveSimpleSourceTable>;
+  metadata: MetadataConnectionEntry | undefined;
+  engine: DatabaseEngine | undefined;
+  nextPage: number;
+  currentPage: number;
+  cursor: unknown;
+}) {
+  if (nextPage !== currentPage + 1 || cursor == null || !engine) {
+    return null;
+  }
+
+  if (!isSimpleTableSelectAll(statement)) {
+    return null;
+  }
+
+  const resolved = resolveKeysetPaginationStrategy(sourceTable, metadata, engine);
+  if (!resolved || !sourceTable?.tableName) {
+    return null;
+  }
+
+  const qi = (name: string) => quoteIdentifier(name, engine);
+  const tableRef = sourceTable.schemaName
+    ? `${qi(sourceTable.schemaName)}.${qi(sourceTable.tableName)}`
+    : qi(sourceTable.tableName);
+  const pk = qi(resolved.pkColumn.columnName);
+  const cursorValue = quoteValue(String(cursor), resolved.pkColumn.dataType, engine);
+
+  return `SELECT * FROM ${tableRef} WHERE ${pk} > ${cursorValue} ORDER BY ${pk} ASC`;
 }
 
 function exportRowsAsCsv(columns: string[], rows: any[], baseName: string) {

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -387,7 +387,7 @@ export default function ResultGrid({
                   const stagedValue = rowPendingEdits?.[col.name];
                   const hasStagedValue = col.name in (rowPendingEdits ?? {});
                   const val = hasStagedValue ? stagedValue : row[col.name];
-                  const displayValue = formatCellValue(val);
+                  const presentation = resolveCellPresentation(val, col.subtitle);
                   const cellKey = `${virtualRow.index}-${col.name}`;
                   const isCopied = copiedCell === cellKey;
                   const isEditing = activeEditCell === cellKey;
@@ -406,7 +406,7 @@ export default function ResultGrid({
                       onDoubleClick={() => {
                         if (!isNewRow) openEdit(cellKey, val);
                       }}
-                      className={`flex items-center gap-1.5 overflow-hidden whitespace-nowrap border-r border-border/20 px-3.5 font-mono text-[13px] transition-colors ${
+                      className={`flex items-center gap-1.5 overflow-hidden whitespace-nowrap border-r border-border/20 px-3.5 font-mono text-[13px] transition-colors ${presentation.alignClass} ${
                         isEditing
                           ? 'bg-primary/10 outline outline-1 outline-primary/60 p-0'
                           : hasStagedValue
@@ -420,7 +420,7 @@ export default function ResultGrid({
                                   : 'cursor-pointer text-ellipsis text-text/94'
                       }`}
                       style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
-                      title={displayValue}
+                      title={presentation.rawValue}
                     >
                       {isEditing ? (
                         <input
@@ -470,10 +470,12 @@ export default function ResultGrid({
                       ) : isCopied ? (
                         <>
                           <Check size={11} className="shrink-0 text-emerald-400" />
-                          <span className="overflow-hidden text-ellipsis">{val === null ? <span className="italic">null</span> : displayValue}</span>
+                          <span className={`min-w-0 overflow-hidden text-ellipsis ${presentation.valueClass}`}>
+                            {renderPresentedValue(presentation)}
+                          </span>
                         </>
                       ) : (
-                        val === null ? <span className="text-muted/50 italic">null</span> : displayValue
+                        renderPresentedValue(presentation)
                       )}
                     </div>
                   );
@@ -530,4 +532,101 @@ function formatCellValue(value: unknown) {
   }
 
   return String(value);
+}
+
+type CellKind = 'null' | 'number' | 'date' | 'boolean' | 'json' | 'text';
+
+function resolveCellPresentation(value: unknown, subtitle?: string | null) {
+  const rawValue = formatCellValue(value);
+  const typeHint = (subtitle ?? '').toLowerCase();
+  const kind = inferCellKind(value, typeHint);
+  const displayValue = kind === 'date' ? formatDatePreview(value, rawValue) : rawValue;
+
+  return {
+    kind,
+    rawValue,
+    displayValue,
+    alignClass: kind === 'number' ? 'justify-end text-right tabular-nums' : '',
+    valueClass: [
+      kind === 'null' ? 'text-muted/50 italic' : '',
+      kind === 'number' ? 'tabular-nums text-cyan-100/95' : '',
+      kind === 'date' ? 'tabular-nums text-violet-100/95' : '',
+      kind === 'json' ? 'text-amber-100/95' : '',
+    ].filter(Boolean).join(' '),
+  };
+}
+
+function inferCellKind(value: unknown, typeHint: string): CellKind {
+  if (value === null || typeof value === 'undefined') {
+    return 'null';
+  }
+
+  if (typeof value === 'boolean' || /\b(bool|boolean)\b/.test(typeHint)) {
+    return 'boolean';
+  }
+
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null) || /\b(json|jsonb|xml)\b/.test(typeHint)) {
+    return 'json';
+  }
+
+  if (/\b(date|time|timestamp|timestamptz)\b/.test(typeHint)) {
+    return 'date';
+  }
+
+  if (
+    typeof value === 'number'
+    || typeof value === 'bigint'
+    || /\b(number|numeric|decimal|integer|int|bigint|smallint|float|double|real|serial|money)\b/.test(typeHint)
+  ) {
+    return 'number';
+  }
+
+  return 'text';
+}
+
+function formatDatePreview(value: unknown, fallback: string) {
+  const raw = value instanceof Date ? value.toISOString() : fallback;
+  const normalized = raw.includes('T') ? raw : raw.replace(' ', 'T');
+  const date = value instanceof Date ? value : new Date(normalized);
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+
+  const hasTime = /[ t]\d{1,2}:\d{2}/i.test(raw);
+  return hasTime
+    ? date.toLocaleString(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    : date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+}
+
+function renderPresentedValue(presentation: ReturnType<typeof resolveCellPresentation>) {
+  if (presentation.kind === 'boolean') {
+    const isTrue = presentation.rawValue.toLowerCase() === 'true' || presentation.rawValue === '1';
+    return (
+      <span className={`inline-flex h-5 shrink-0 items-center rounded border px-1.5 text-[10px] font-semibold uppercase tracking-wide ${
+        isTrue
+          ? 'border-emerald-400/30 bg-emerald-400/12 text-emerald-200'
+          : 'border-border/70 bg-background/35 text-muted'
+      }`}>
+        {presentation.rawValue}
+      </span>
+    );
+  }
+
+  return (
+    <span className={`min-w-0 overflow-hidden text-ellipsis ${presentation.valueClass}`}>
+      {presentation.displayValue}
+    </span>
+  );
 }

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowUp, ArrowDown, Check, Copy, PanelRightOpen, Pencil, X } from 'lucide-react';
+import { ArrowUp, ArrowDown, Check, Copy, EyeOff, Filter, MoreVertical, PanelRightOpen, Pencil, Pin, X } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { writeText as clipboardWriteText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -20,6 +20,8 @@ interface ResultGridProps {
   focusNewRowToken?: number;
   selectedRowIndex?: number | null;
   onRowSelect?: (rowIndex: number, row: Record<string, unknown>) => void;
+  layoutKey?: string | null;
+  onFocusQuickFilter?: () => void;
 }
 
 export default function ResultGrid({
@@ -33,6 +35,8 @@ export default function ResultGrid({
   focusNewRowToken,
   selectedRowIndex = null,
   onRowSelect,
+  layoutKey = null,
+  onFocusQuickFilter,
 }: ResultGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
@@ -47,6 +51,11 @@ export default function ResultGrid({
   const [activeEditCell, setActiveEditCell] = useState<string | null>(null);
   const [selectedCell, setSelectedCell] = useState<{ rowIndex: number; column: string } | null>(null);
   const [detailCell, setDetailCell] = useState<{ rowIndex: number; column: string } | null>(null);
+  const [selectionAnchor, setSelectionAnchor] = useState<{ rowIndex: number; column: string } | null>(null);
+  const [columnMenu, setColumnMenu] = useState<{ x: number; y: number; column: string } | null>(null);
+  const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
+  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
+  const [pinnedColumns, setPinnedColumns] = useState<Set<string>>(new Set());
   const [editDraft, setEditDraft] = useState('');
   const skipNextBlurRef = useRef(false);
   const editInputRef = useRef<HTMLInputElement>(null);
@@ -62,6 +71,40 @@ export default function ResultGrid({
     [columnWidths, columns, rows],
   );
 
+  const storageKey = useMemo(
+    () => `pulsesql:grid-layout:${layoutKey ?? columns.map((column) => column.name).join('|')}`,
+    [columns, layoutKey],
+  );
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as {
+        widths?: Record<string, number>;
+        hidden?: string[];
+        pinned?: string[];
+      };
+      if (parsed.widths) setColumnWidths(parsed.widths);
+      if (parsed.hidden) setHiddenColumns(new Set(parsed.hidden));
+      if (parsed.pinned) setPinnedColumns(new Set(parsed.pinned));
+    } catch {
+      // Ignore corrupted local layout state.
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify({
+        widths: columnWidths,
+        hidden: [...hiddenColumns],
+        pinned: [...pinnedColumns],
+      }));
+    } catch {
+      // Layout persistence is best-effort.
+    }
+  }, [columnWidths, hiddenColumns, pinnedColumns, storageKey]);
+
   const sortedRows = useMemo(() => {
     if (!sortConfig) return rows;
     const { column, dir } = sortConfig;
@@ -75,6 +118,38 @@ export default function ResultGrid({
     });
   }, [rows, sortConfig]);
 
+  const filteredRows = useMemo(() => {
+    const activeFilters = Object.entries(columnFilters).filter(([, value]) => value.trim());
+    if (!activeFilters.length) return sortedRows;
+
+    return sortedRows.filter((row) =>
+      activeFilters.every(([column, rawFilter]) => matchColumnFilter(row?.[column], rawFilter)),
+    );
+  }, [columnFilters, sortedRows]);
+
+  const visibleColumns = useMemo(
+    () => columns.filter((column) => !hiddenColumns.has(column.name)),
+    [columns, hiddenColumns],
+  );
+  const pinnedVisibleColumns = useMemo(
+    () => visibleColumns.filter((column) => pinnedColumns.has(column.name)),
+    [pinnedColumns, visibleColumns],
+  );
+  const scrollVisibleColumns = useMemo(
+    () => visibleColumns.filter((column) => !pinnedColumns.has(column.name)),
+    [pinnedColumns, visibleColumns],
+  );
+  const pinnedOffsets = useMemo(() => {
+    let left = 48;
+    const entries: Array<[string, number]> = [];
+    pinnedVisibleColumns.forEach((column) => {
+      entries.push([column.name, left]);
+      left += resolvedWidths[column.name];
+    });
+    return Object.fromEntries(entries);
+  }, [pinnedVisibleColumns, resolvedWidths]);
+  const pinnedWidth = pinnedVisibleColumns.reduce((total, column) => total + resolvedWidths[column.name], 0);
+
   const handleSortToggle = (colName: string) => {
     setSortConfig((current) => {
       if (current?.column === colName) {
@@ -86,13 +161,21 @@ export default function ResultGrid({
 
   const rowHeight = density === 'compact' ? 26 : 30;
   const headerHeight = density === 'compact' ? 40 : 44;
-  const allRows = [...sortedRows, ...(pendingNewRows ?? [])];
+  const allRows = [...filteredRows, ...(pendingNewRows ?? [])];
 
   const rowVirtualizer = useVirtualizer({
     count: allRows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => rowHeight,
     overscan: 20,
+  });
+
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: scrollVisibleColumns.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (index) => resolvedWidths[scrollVisibleColumns[index]?.name] ?? 140,
+    overscan: 5,
   });
 
   useEffect(() => {
@@ -163,6 +246,37 @@ export default function ResultGrid({
     return Number.isNaN(idx) ? null : idx;
   })();
 
+  const selectedRange = useMemo(() => {
+    if (!selectionAnchor || !selectedCell) return null;
+    const startColumnIndex = visibleColumns.findIndex((column) => column.name === selectionAnchor.column);
+    const endColumnIndex = visibleColumns.findIndex((column) => column.name === selectedCell.column);
+    if (startColumnIndex < 0 || endColumnIndex < 0) return null;
+
+    return {
+      rowStart: Math.min(selectionAnchor.rowIndex, selectedCell.rowIndex),
+      rowEnd: Math.max(selectionAnchor.rowIndex, selectedCell.rowIndex),
+      colStart: Math.min(startColumnIndex, endColumnIndex),
+      colEnd: Math.max(startColumnIndex, endColumnIndex),
+    };
+  }, [selectedCell, selectionAnchor, visibleColumns]);
+
+  const copyRange = (includeHeaders = false) => {
+    if (!selectedRange) return false;
+    const selectedColumns = visibleColumns.slice(selectedRange.colStart, selectedRange.colEnd + 1);
+    const lines: string[] = [];
+    if (includeHeaders) {
+      lines.push(selectedColumns.map((column) => column.name).join('\t'));
+    }
+
+    for (let rowIndex = selectedRange.rowStart; rowIndex <= selectedRange.rowEnd; rowIndex++) {
+      const row = allRows[rowIndex] as Record<string, unknown> | undefined;
+      lines.push(selectedColumns.map((column) => formatTsvValue(row?.[column.name])).join('\t'));
+    }
+
+    void clipboardWriteText(lines.join('\n'));
+    return true;
+  };
+
   const handleCopyCell = (cellKey: string, value: unknown) => {
     const text = value === null ? '' : formatCellValue(value);
     void clipboardWriteText(text);
@@ -171,9 +285,14 @@ export default function ResultGrid({
     copyTimeoutRef.current = window.setTimeout(() => setCopiedCell(null), 1200);
   };
 
-  const handleCellClick = (colName: string, rowIndex: number) => {
+  const handleCellClick = (colName: string, rowIndex: number, shiftKey = false) => {
     if (anyEditActive && lockedRowIndex === rowIndex) return;
     if (activeEditCell) return;
+    if (shiftKey && selectedCell) {
+      setSelectionAnchor(selectionAnchor ?? selectedCell);
+    } else {
+      setSelectionAnchor({ rowIndex, column: colName });
+    }
     setSelectedCell({ rowIndex, column: colName });
     parentRef.current?.focus();
   };
@@ -217,6 +336,13 @@ export default function ResultGrid({
     }
   }, [allRows.length, columns, detailCell]);
 
+  useEffect(() => {
+    if (!columnMenu) return;
+    const close = () => setColumnMenu(null);
+    window.addEventListener('mousedown', close);
+    return () => window.removeEventListener('mousedown', close);
+  }, [columnMenu]);
+
   const detailContext = useMemo(() => {
     if (!detailCell) return null;
 
@@ -224,7 +350,7 @@ export default function ResultGrid({
     const column = columns.find((item) => item.name === detailCell.column);
     if (!row || !column) return null;
 
-    const rowPendingEdits = detailCell.rowIndex >= sortedRows.length ? null : (pendingRowEdits?.get(row) ?? null);
+    const rowPendingEdits = detailCell.rowIndex >= filteredRows.length ? null : (pendingRowEdits?.get(row) ?? null);
     const hasStagedValue = column.name in (rowPendingEdits ?? {});
     const value = hasStagedValue ? rowPendingEdits?.[column.name] : row[column.name];
     const presentation = resolveCellPresentation(value, column.subtitle);
@@ -237,7 +363,7 @@ export default function ResultGrid({
       cellKey: `${detailCell.rowIndex}-${column.name}`,
       rowNumber: rowNumberOffset + detailCell.rowIndex + 1,
     };
-  }, [allRows, columns, detailCell, pendingRowEdits, rowNumberOffset, sortedRows.length]);
+  }, [allRows, columns, detailCell, filteredRows.length, pendingRowEdits, rowNumberOffset]);
 
   const handleGridKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Escape' && detailCell) {
@@ -250,6 +376,10 @@ export default function ResultGrid({
 
     const isCopy = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'c';
     if (isCopy) {
+      if (selectedRange && copyRange(event.shiftKey)) {
+        event.preventDefault();
+        return;
+      }
       const row = allRows[selectedCell.rowIndex] as Record<string, unknown> | undefined;
       if (!row) return;
       event.preventDefault();
@@ -258,13 +388,31 @@ export default function ResultGrid({
       return;
     }
 
-    const currentColumnIndex = columns.findIndex((column) => column.name === selectedCell.column);
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'a') {
+      event.preventDefault();
+      if (allRows.length && visibleColumns.length) {
+        setSelectionAnchor({ rowIndex: 0, column: visibleColumns[0].name });
+        setSelectedCell({
+          rowIndex: allRows.length - 1,
+          column: visibleColumns[visibleColumns.length - 1].name,
+        });
+      }
+      return;
+    }
+
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
+      event.preventDefault();
+      onFocusQuickFilter?.();
+      return;
+    }
+
+    const currentColumnIndex = visibleColumns.findIndex((column) => column.name === selectedCell.column);
     if (currentColumnIndex < 0) return;
 
     if (event.key === 'ArrowRight' || event.key === 'ArrowLeft' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault();
       const nextColumnIndex = event.key === 'ArrowRight'
-        ? Math.min(columns.length - 1, currentColumnIndex + 1)
+        ? Math.min(visibleColumns.length - 1, currentColumnIndex + 1)
         : event.key === 'ArrowLeft'
           ? Math.max(0, currentColumnIndex - 1)
           : currentColumnIndex;
@@ -274,7 +422,12 @@ export default function ResultGrid({
           ? Math.max(0, selectedCell.rowIndex - 1)
           : selectedCell.rowIndex;
 
-      setSelectedCell({ rowIndex: nextRowIndex, column: columns[nextColumnIndex].name });
+      if (!event.shiftKey) {
+        setSelectionAnchor({ rowIndex: nextRowIndex, column: visibleColumns[nextColumnIndex].name });
+      } else {
+        setSelectionAnchor(selectionAnchor ?? selectedCell);
+      }
+      setSelectedCell({ rowIndex: nextRowIndex, column: visibleColumns[nextColumnIndex].name });
       rowVirtualizer.scrollToIndex(nextRowIndex, { behavior: 'auto' });
       return;
     }
@@ -286,6 +439,10 @@ export default function ResultGrid({
       openEdit(`${selectedCell.rowIndex}-${selectedCell.column}`, row[selectedCell.column]);
     }
   };
+
+  const virtualColumns = columnVirtualizer.getVirtualItems();
+  const totalGridWidth = 48 + pinnedWidth + columnVirtualizer.getTotalSize();
+  const activeMenuColumn = columnMenu ? columns.find((column) => column.name === columnMenu.column) : null;
 
   return (
     <div
@@ -302,31 +459,39 @@ export default function ResultGrid({
       <div
         className={`min-w-fit ${allRows.length ? '' : 'hidden'}`}
         style={{
+          width: `${totalGridWidth}px`,
           height: `${rowVirtualizer.getTotalSize() + headerHeight}px`,
           position: 'relative',
         }}
       >
         <div
-          className="sticky top-0 z-10 flex border-b border-border/80 bg-surface/95 text-[11px] text-muted backdrop-blur"
-          style={{ height: headerHeight }}
+          className="sticky top-0 z-10 border-b border-border/80 bg-surface/95 text-[11px] text-muted backdrop-blur"
+          style={{ height: headerHeight, width: `${totalGridWidth}px` }}
         >
-          <div className="sticky left-0 w-12 shrink-0 select-none border-r border-border/35 bg-surface/95 px-2 py-2 text-center opacity-45">
+          <div className="sticky left-0 z-30 flex h-full w-12 shrink-0 select-none items-center justify-center border-r border-border/35 bg-surface/95 px-2 py-2 text-center opacity-85">
             #
           </div>
-          {columns.map((col, idx) => {
+          {[...pinnedVisibleColumns, ...virtualColumns.map((item) => scrollVisibleColumns[item.index]).filter(Boolean)].map((col) => {
             const isSorted = sortConfig?.column === col.name;
+            const virtualItem = pinnedColumns.has(col.name)
+              ? null
+              : virtualColumns.find((item) => scrollVisibleColumns[item.index]?.name === col.name);
+            const left = pinnedColumns.has(col.name)
+              ? pinnedOffsets[col.name]
+              : 48 + pinnedWidth + (virtualItem?.start ?? 0);
             return (
               <div
-                key={idx}
-                className="relative border-r border-border/35"
-                style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
+                key={col.name}
+                className={`absolute top-0 h-full border-r border-border/35 bg-surface/95 ${pinnedColumns.has(col.name) ? 'sticky z-20' : ''}`}
+                style={{ left, width: `${resolvedWidths[col.name]}px` }}
               >
                 <div
-                  className="cursor-pointer select-none overflow-hidden whitespace-nowrap px-3 py-1.5 leading-tight text-ellipsis hover:bg-background/28"
+                  className="flex h-full cursor-pointer select-none items-center gap-1.5 overflow-hidden whitespace-nowrap px-3 py-1.5 leading-tight text-ellipsis hover:bg-background/28"
                   onClick={() => handleSortToggle(col.name)}
                   title={`Ordenar por ${col.name}`}
                 >
-                  <div className="flex items-center gap-1.5 overflow-hidden">
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <div className="flex items-center gap-1.5 overflow-hidden">
                     <span className={`overflow-hidden text-ellipsis font-mono text-[12px] normal-case tracking-normal ${isSorted ? 'text-primary' : 'text-text/92'}`}>
                       {col.name}
                     </span>
@@ -345,12 +510,26 @@ export default function ResultGrid({
                         FK
                       </span>
                     ) : null}
-                  </div>
-                  {col.subtitle ? (
-                    <div className="overflow-hidden text-ellipsis text-[10px] font-normal normal-case tracking-normal text-muted/60">
-                      {col.subtitle}
+                    {columnFilters[col.name]?.trim() ? <Filter size={10} className="shrink-0 text-primary" /> : null}
+                    {pinnedColumns.has(col.name) ? <Pin size={10} className="shrink-0 text-primary" /> : null}
                     </div>
-                  ) : null}
+                    {col.subtitle ? (
+                      <div className="overflow-hidden text-ellipsis text-[10px] font-normal normal-case tracking-normal text-muted/60">
+                        {col.subtitle}
+                      </div>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setColumnMenu({ x: event.clientX, y: event.clientY, column: col.name });
+                    }}
+                    className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted hover:bg-border/30 hover:text-text"
+                    title="Menu da coluna"
+                  >
+                    <MoreVertical size={12} />
+                  </button>
                 </div>
                 <div
                   role="separator"
@@ -373,10 +552,10 @@ export default function ResultGrid({
           })}
         </div>
         
-        <div className="absolute w-full" style={{ top: `${headerHeight}px` }}>
+        <div className="absolute" style={{ top: `${headerHeight}px`, width: `${totalGridWidth}px` }}>
           {rowVirtualizer.getVirtualItems().map((virtualRow) => {
             const row = allRows[virtualRow.index] as Record<string, unknown>;
-            const isNewRow = virtualRow.index >= sortedRows.length;
+            const isNewRow = virtualRow.index >= filteredRows.length;
             const rowPendingEdits = isNewRow ? null : (pendingRowEdits?.get(row) ?? null);
             const isDirtyRow = !isNewRow && rowPendingEdits != null;
             const rowTone = virtualRow.index % 2 === 0 ? 'bg-background/70' : 'bg-surface/26';
@@ -385,7 +564,7 @@ export default function ResultGrid({
             return (
               <div
                 key={virtualRow.key}
-                className={`group absolute flex w-full border-b text-sm transition-colors ${
+                className={`group absolute w-full border-b text-sm transition-colors ${
                   isNewRow
                     ? 'border-emerald-400/20 bg-emerald-400/6'
                     : isDirtyRow
@@ -400,6 +579,7 @@ export default function ResultGrid({
                 }`}
                 style={{
                   height: `${virtualRow.size}px`,
+                  width: `${totalGridWidth}px`,
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
@@ -419,7 +599,7 @@ export default function ResultGrid({
                 >
                   {isNewRow ? '+' : rowNumberOffset + virtualRow.index + 1}
                 </button>
-                {columns.map((col, cIdx) => {
+                {[...pinnedVisibleColumns, ...virtualColumns.map((item) => scrollVisibleColumns[item.index]).filter(Boolean)].map((col) => {
                   const stagedValue = rowPendingEdits?.[col.name];
                   const hasStagedValue = col.name in (rowPendingEdits ?? {});
                   const val = hasStagedValue ? stagedValue : row[col.name];
@@ -428,22 +608,35 @@ export default function ResultGrid({
                   const isCopied = copiedCell === cellKey;
                   const isEditing = activeEditCell === cellKey;
                   const isSelectedCell = selectedCell?.rowIndex === virtualRow.index && selectedCell.column === col.name;
+                  const columnIndex = visibleColumns.findIndex((column) => column.name === col.name);
+                  const isInRange = selectedRange
+                    ? virtualRow.index >= selectedRange.rowStart
+                      && virtualRow.index <= selectedRange.rowEnd
+                      && columnIndex >= selectedRange.colStart
+                      && columnIndex <= selectedRange.colEnd
+                    : false;
                   const isInactiveCell = isThisRowLocked && !isEditing;
                   const canOpenDetail = shouldOfferDetail(presentation);
+                  const virtualItem = pinnedColumns.has(col.name)
+                    ? null
+                    : virtualColumns.find((item) => scrollVisibleColumns[item.index]?.name === col.name);
+                  const left = pinnedColumns.has(col.name)
+                    ? pinnedOffsets[col.name]
+                    : 48 + pinnedWidth + (virtualItem?.start ?? 0);
                   return (
                     <div
-                      key={cIdx}
-                      onClick={() => {
+                      key={col.name}
+                      onClick={(event) => {
                         if (isNewRow && !isEditing) {
                           openEdit(cellKey, val);
                           return;
                         }
-                        handleCellClick(col.name, virtualRow.index);
+                        handleCellClick(col.name, virtualRow.index, event.shiftKey);
                       }}
                       onDoubleClick={() => {
                         if (!isNewRow) openEdit(cellKey, val);
                       }}
-                      className={`flex items-center gap-1.5 overflow-hidden whitespace-nowrap border-r border-border/20 px-3.5 font-mono text-[13px] transition-colors ${presentation.alignClass} ${
+                      className={`absolute top-0 flex h-full items-center gap-1.5 overflow-hidden whitespace-nowrap border-r border-border/20 px-3.5 font-mono text-[13px] transition-colors ${presentation.alignClass} ${
                         isEditing
                           ? 'bg-primary/10 outline outline-1 outline-primary/60 p-0'
                           : hasStagedValue
@@ -454,9 +647,11 @@ export default function ResultGrid({
                                 ? 'bg-emerald-400/16 text-emerald-100'
                                 : isSelectedCell
                                   ? 'cursor-pointer text-ellipsis bg-primary/10 text-text ring-1 ring-inset ring-primary/45'
-                                  : 'cursor-pointer text-ellipsis text-text/94'
+                                  : isInRange
+                                    ? 'cursor-pointer text-ellipsis bg-primary/6 text-text/94'
+                                    : 'cursor-pointer text-ellipsis text-text/94'
                       }`}
-                      style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
+                      style={{ left, width: `${resolvedWidths[col.name]}px` }}
                       title={presentation.rawValue}
                     >
                       {isEditing ? (
@@ -599,6 +794,86 @@ export default function ResultGrid({
           </pre>
         </div>
       ) : null}
+      {columnMenu && activeMenuColumn ? (
+        <div
+          className="fixed z-50 w-64 rounded-lg border border-border bg-surface p-2 text-xs text-text shadow-2xl"
+          style={{ left: columnMenu.x, top: columnMenu.y }}
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <div className="mb-2 border-b border-border/60 px-1 pb-2">
+            <div className="truncate font-mono text-[12px] font-semibold">{activeMenuColumn.name}</div>
+            <div className="mt-0.5 truncate text-[11px] text-muted">
+              {activeMenuColumn.subtitle ?? 'tipo desconhecido'}
+              {activeMenuColumn.isPrimaryKey ? ' · PK' : ''}
+              {activeMenuColumn.isForeignKey ? ' · FK' : ''}
+            </div>
+          </div>
+          <div className="grid gap-1">
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => { setSortConfig({ column: activeMenuColumn.name, dir: 'asc' }); setColumnMenu(null); }}>
+              <ArrowUp size={12} /> Ordenar crescente
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => { setSortConfig({ column: activeMenuColumn.name, dir: 'desc' }); setColumnMenu(null); }}>
+              <ArrowDown size={12} /> Ordenar decrescente
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => { setSortConfig((current) => current?.column === activeMenuColumn.name ? null : current); setColumnMenu(null); }}>
+              <X size={12} /> Limpar ordenacao
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => { void clipboardWriteText(activeMenuColumn.name); setColumnMenu(null); }}>
+              <Copy size={12} /> Copiar nome
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => {
+              setColumnWidths((current) => ({ ...current, [activeMenuColumn.name]: estimateColumnWidth(activeMenuColumn, allRows) }));
+              setColumnMenu(null);
+            }}>
+              <Check size={12} /> Autoajustar largura
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => {
+              setPinnedColumns((current) => {
+                const next = new Set(current);
+                if (next.has(activeMenuColumn.name)) next.delete(activeMenuColumn.name);
+                else next.add(activeMenuColumn.name);
+                return next;
+              });
+              setColumnMenu(null);
+            }}>
+              <Pin size={12} /> {pinnedColumns.has(activeMenuColumn.name) ? 'Desfixar coluna' : 'Fixar coluna'}
+            </button>
+            <button type="button" className="inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted transition-colors hover:bg-border/30 hover:text-text" onClick={() => {
+              setHiddenColumns((current) => {
+                const next = new Set(current);
+                next.add(activeMenuColumn.name);
+                return next.size >= columns.length ? current : next;
+              });
+              setPinnedColumns((current) => {
+                const next = new Set(current);
+                next.delete(activeMenuColumn.name);
+                return next;
+              });
+              setColumnMenu(null);
+            }}>
+              <EyeOff size={12} /> Ocultar coluna
+            </button>
+          </div>
+          <label className="mt-2 flex items-center gap-2 rounded-md border border-border/70 bg-background/30 px-2 py-1.5">
+            <Filter size={12} className="text-muted" />
+            <input
+              value={columnFilters[activeMenuColumn.name] ?? ''}
+              onChange={(event) => setColumnFilters((current) => ({ ...current, [activeMenuColumn.name]: event.target.value }))}
+              placeholder="Filtro local"
+              className="min-w-0 flex-1 bg-transparent text-xs text-text outline-none placeholder:text-muted"
+            />
+          </label>
+          {hiddenColumns.size ? (
+            <button
+              type="button"
+              className="mt-2 w-full rounded-md border border-border/70 px-2 py-1.5 text-left text-xs text-muted hover:bg-border/30 hover:text-text"
+              onClick={() => setHiddenColumns(new Set())}
+            >
+              Mostrar colunas ocultas ({hiddenColumns.size})
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -646,6 +921,43 @@ function formatCellValue(value: unknown) {
   }
 
   return String(value);
+}
+
+function formatTsvValue(value: unknown) {
+  return formatCellValue(value)
+    .replace(/\t/g, ' ')
+    .replace(/\r?\n/g, ' ');
+}
+
+function matchColumnFilter(value: unknown, rawFilter: string) {
+  const filter = rawFilter.trim();
+  if (!filter) return true;
+  const normalizedValue = formatCellValue(value).toLowerCase();
+  const normalizedFilter = filter.toLowerCase();
+
+  if (normalizedFilter === 'null' || normalizedFilter === 'is:null') {
+    return value === null || typeof value === 'undefined';
+  }
+
+  if (normalizedFilter === '!null' || normalizedFilter === 'not:null') {
+    return value !== null && typeof value !== 'undefined';
+  }
+
+  const operator = filter.match(/^(>=|<=|>|<|=)\s*(.+)$/);
+  if (operator) {
+    const target = Number(operator[2]);
+    const actual = typeof value === 'number' ? value : Number(String(value ?? '').replace(',', '.'));
+    if (!Number.isFinite(actual) || !Number.isFinite(target)) {
+      return normalizedValue === operator[2].toLowerCase();
+    }
+    if (operator[1] === '>') return actual > target;
+    if (operator[1] === '>=') return actual >= target;
+    if (operator[1] === '<') return actual < target;
+    if (operator[1] === '<=') return actual <= target;
+    return actual === target;
+  }
+
+  return normalizedValue.includes(normalizedFilter);
 }
 
 function formatDetailValue(value: unknown) {

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -45,6 +45,7 @@ export default function ResultGrid({
   const [copiedCell, setCopiedCell] = useState<string | null>(null);
   const copyTimeoutRef = useRef<number | null>(null);
   const [activeEditCell, setActiveEditCell] = useState<string | null>(null);
+  const [selectedCell, setSelectedCell] = useState<{ rowIndex: number; column: string } | null>(null);
   const [editDraft, setEditDraft] = useState('');
   const skipNextBlurRef = useRef(false);
   const editInputRef = useRef<HTMLInputElement>(null);
@@ -161,14 +162,19 @@ export default function ResultGrid({
     return Number.isNaN(idx) ? null : idx;
   })();
 
-  const handleCellClick = (cellKey: string, value: unknown, rowIndex: number) => {
-    if (anyEditActive && lockedRowIndex === rowIndex) return;
-    if (activeEditCell) return;
+  const handleCopyCell = (cellKey: string, value: unknown) => {
     const text = value === null ? '' : formatCellValue(value);
     void clipboardWriteText(text);
     if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
     setCopiedCell(cellKey);
     copyTimeoutRef.current = window.setTimeout(() => setCopiedCell(null), 1200);
+  };
+
+  const handleCellClick = (colName: string, rowIndex: number) => {
+    if (anyEditActive && lockedRowIndex === rowIndex) return;
+    if (activeEditCell) return;
+    setSelectedCell({ rowIndex, column: colName });
+    parentRef.current?.focus();
   };
 
   const openEdit = (cellKey: string, value: unknown) => {
@@ -196,8 +202,62 @@ export default function ResultGrid({
     }
   }, [activeEditCell]);
 
+  useEffect(() => {
+    if (!selectedCell) return;
+    if (selectedCell.rowIndex >= allRows.length || !columns.some((column) => column.name === selectedCell.column)) {
+      setSelectedCell(null);
+    }
+  }, [allRows.length, columns, selectedCell]);
+
+  const handleGridKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (activeEditCell || !selectedCell) return;
+
+    const isCopy = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'c';
+    if (isCopy) {
+      const row = allRows[selectedCell.rowIndex] as Record<string, unknown> | undefined;
+      if (!row) return;
+      event.preventDefault();
+      const cellKey = `${selectedCell.rowIndex}-${selectedCell.column}`;
+      handleCopyCell(cellKey, row[selectedCell.column]);
+      return;
+    }
+
+    const currentColumnIndex = columns.findIndex((column) => column.name === selectedCell.column);
+    if (currentColumnIndex < 0) return;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const nextColumnIndex = event.key === 'ArrowRight'
+        ? Math.min(columns.length - 1, currentColumnIndex + 1)
+        : event.key === 'ArrowLeft'
+          ? Math.max(0, currentColumnIndex - 1)
+          : currentColumnIndex;
+      const nextRowIndex = event.key === 'ArrowDown'
+        ? Math.min(allRows.length - 1, selectedCell.rowIndex + 1)
+        : event.key === 'ArrowUp'
+          ? Math.max(0, selectedCell.rowIndex - 1)
+          : selectedCell.rowIndex;
+
+      setSelectedCell({ rowIndex: nextRowIndex, column: columns[nextColumnIndex].name });
+      rowVirtualizer.scrollToIndex(nextRowIndex, { behavior: 'auto' });
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      const row = allRows[selectedCell.rowIndex] as Record<string, unknown> | undefined;
+      if (!row) return;
+      event.preventDefault();
+      openEdit(`${selectedCell.rowIndex}-${selectedCell.column}`, row[selectedCell.column]);
+    }
+  };
+
   return (
-    <div ref={parentRef} className="h-full w-full overflow-auto bg-transparent relative">
+    <div
+      ref={parentRef}
+      tabIndex={0}
+      onKeyDown={handleGridKeyDown}
+      className="h-full w-full overflow-auto bg-transparent relative outline-none"
+    >
       {!allRows.length ? (
         <div className="h-full flex items-center justify-center text-sm text-muted/60">
           Nenhum resultado para o filtro aplicado.
@@ -331,6 +391,7 @@ export default function ResultGrid({
                   const cellKey = `${virtualRow.index}-${col.name}`;
                   const isCopied = copiedCell === cellKey;
                   const isEditing = activeEditCell === cellKey;
+                  const isSelectedCell = selectedCell?.rowIndex === virtualRow.index && selectedCell.column === col.name;
                   const isInactiveCell = isThisRowLocked && !isEditing;
                   return (
                     <div
@@ -340,7 +401,7 @@ export default function ResultGrid({
                           openEdit(cellKey, val);
                           return;
                         }
-                        handleCellClick(cellKey, val, virtualRow.index);
+                        handleCellClick(col.name, virtualRow.index);
                       }}
                       onDoubleClick={() => {
                         if (!isNewRow) openEdit(cellKey, val);
@@ -354,7 +415,9 @@ export default function ResultGrid({
                               ? 'pointer-events-none select-none text-text opacity-35'
                               : isCopied
                                 ? 'bg-emerald-400/16 text-emerald-100'
-                                : 'cursor-pointer text-ellipsis text-text/94'
+                                : isSelectedCell
+                                  ? 'cursor-pointer text-ellipsis bg-primary/10 text-text ring-1 ring-inset ring-primary/45'
+                                  : 'cursor-pointer text-ellipsis text-text/94'
                       }`}
                       style={{ width: `${resolvedWidths[col.name]}px`, minWidth: `${resolvedWidths[col.name]}px` }}
                       title={displayValue}

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowUp, ArrowDown, Check } from 'lucide-react';
+import { ArrowUp, ArrowDown, Check, Copy, PanelRightOpen, Pencil, X } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { writeText as clipboardWriteText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -46,6 +46,7 @@ export default function ResultGrid({
   const copyTimeoutRef = useRef<number | null>(null);
   const [activeEditCell, setActiveEditCell] = useState<string | null>(null);
   const [selectedCell, setSelectedCell] = useState<{ rowIndex: number; column: string } | null>(null);
+  const [detailCell, setDetailCell] = useState<{ rowIndex: number; column: string } | null>(null);
   const [editDraft, setEditDraft] = useState('');
   const skipNextBlurRef = useRef(false);
   const editInputRef = useRef<HTMLInputElement>(null);
@@ -209,7 +210,42 @@ export default function ResultGrid({
     }
   }, [allRows.length, columns, selectedCell]);
 
+  useEffect(() => {
+    if (!detailCell) return;
+    if (detailCell.rowIndex >= allRows.length || !columns.some((column) => column.name === detailCell.column)) {
+      setDetailCell(null);
+    }
+  }, [allRows.length, columns, detailCell]);
+
+  const detailContext = useMemo(() => {
+    if (!detailCell) return null;
+
+    const row = allRows[detailCell.rowIndex] as Record<string, unknown> | undefined;
+    const column = columns.find((item) => item.name === detailCell.column);
+    if (!row || !column) return null;
+
+    const rowPendingEdits = detailCell.rowIndex >= sortedRows.length ? null : (pendingRowEdits?.get(row) ?? null);
+    const hasStagedValue = column.name in (rowPendingEdits ?? {});
+    const value = hasStagedValue ? rowPendingEdits?.[column.name] : row[column.name];
+    const presentation = resolveCellPresentation(value, column.subtitle);
+
+    return {
+      row,
+      column,
+      value,
+      presentation,
+      cellKey: `${detailCell.rowIndex}-${column.name}`,
+      rowNumber: rowNumberOffset + detailCell.rowIndex + 1,
+    };
+  }, [allRows, columns, detailCell, pendingRowEdits, rowNumberOffset, sortedRows.length]);
+
   const handleGridKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && detailCell) {
+      event.preventDefault();
+      setDetailCell(null);
+      return;
+    }
+
     if (activeEditCell || !selectedCell) return;
 
     const isCopy = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'c';
@@ -393,6 +429,7 @@ export default function ResultGrid({
                   const isEditing = activeEditCell === cellKey;
                   const isSelectedCell = selectedCell?.rowIndex === virtualRow.index && selectedCell.column === col.name;
                   const isInactiveCell = isThisRowLocked && !isEditing;
+                  const canOpenDetail = shouldOfferDetail(presentation);
                   return (
                     <div
                       key={cIdx}
@@ -477,6 +514,22 @@ export default function ResultGrid({
                       ) : (
                         renderPresentedValue(presentation)
                       )}
+                      {!isEditing && canOpenDetail ? (
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setSelectedCell({ rowIndex: virtualRow.index, column: col.name });
+                            setDetailCell({ rowIndex: virtualRow.index, column: col.name });
+                          }}
+                          className={`ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border/60 bg-background/40 text-muted transition-colors hover:border-primary/45 hover:text-text ${
+                            isSelectedCell ? 'opacity-100' : 'opacity-55 hover:opacity-100'
+                          }`}
+                          title="Abrir detalhe"
+                        >
+                          <PanelRightOpen size={12} />
+                        </button>
+                      ) : null}
                     </div>
                   );
                 })}
@@ -485,6 +538,67 @@ export default function ResultGrid({
           })}
         </div>
       </div>
+      {detailContext ? (
+        <div className="absolute bottom-3 right-3 z-20 flex max-h-[min(70%,420px)] w-[min(520px,calc(100%-24px))] flex-col overflow-hidden rounded-lg border border-border bg-surface text-xs text-text shadow-2xl">
+          <div className="flex items-start gap-3 border-b border-border/70 px-3 py-2.5">
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate font-mono text-[12px] font-semibold text-text">
+                  {detailContext.column.name}
+                </span>
+                {detailContext.column.isPrimaryKey ? (
+                  <span className="shrink-0 rounded border border-amber-400/30 bg-amber-400/18 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-amber-300">
+                    PK
+                  </span>
+                ) : null}
+                {detailContext.column.isForeignKey ? (
+                  <span className="shrink-0 rounded border border-sky-400/30 bg-sky-400/18 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-sky-300">
+                    FK
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-0.5 truncate text-[11px] text-muted">
+                Linha {detailContext.rowNumber}
+                {detailContext.column.subtitle ? ` · ${detailContext.column.subtitle}` : ''}
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                onClick={() => handleCopyCell(detailContext.cellKey, detailContext.value)}
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 text-muted transition-colors hover:bg-border/30 hover:text-text"
+                title="Copiar valor"
+              >
+                <Copy size={13} />
+              </button>
+              {onCellChange && !detailContext.column.isAutoIncrement ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDetailCell(null);
+                    openEdit(detailContext.cellKey, detailContext.value);
+                  }}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 text-muted transition-colors hover:bg-border/30 hover:text-text"
+                  title="Editar valor"
+                >
+                  <Pencil size={13} />
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => setDetailCell(null)}
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 text-muted transition-colors hover:bg-border/30 hover:text-text"
+                title="Fechar"
+              >
+                <X size={13} />
+              </button>
+            </div>
+          </div>
+          <pre className="min-h-[120px] overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-[12px] leading-5 text-text/95">
+            {formatDetailValue(detailContext.value)}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -532,6 +646,18 @@ function formatCellValue(value: unknown) {
   }
 
   return String(value);
+}
+
+function formatDetailValue(value: unknown) {
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return formatCellValue(value);
+    }
+  }
+
+  return formatCellValue(value);
 }
 
 type CellKind = 'null' | 'number' | 'date' | 'boolean' | 'json' | 'text';
@@ -629,4 +755,8 @@ function renderPresentedValue(presentation: ReturnType<typeof resolveCellPresent
       {presentation.displayValue}
     </span>
   );
+}
+
+function shouldOfferDetail(presentation: ReturnType<typeof resolveCellPresentation>) {
+  return presentation.kind === 'json' || presentation.rawValue.length > 80 || presentation.rawValue.includes('\n');
 }


### PR DESCRIPTION
## Summary

- Eliminate COUNT(*) from critical query path — first page responds with a single SQL operation
- Async background count via new `count_query` Tauri command; UI updates total when ready
- `pageSize + 1` trick to detect `has_more` without COUNT
- Persistent JDBC connections in Oracle sidecar — no per-query reconnect
- Oracle sidecar calls run off async workers via `spawn_blocking` (no Tauri worker blocking)
- Per-engine diagnostics: `prepare_ms`, `count_ms`, `data_ms`, `serialize_ms`, `payload_bytes`
- Professional result grid: cell selection, keyboard navigation, type-aware rendering, cell detail panel, refined toolbar

## Test plan

- [ ] Run a SELECT on Postgres — verify first page arrives without COUNT delay
- [ ] Navigate to page 2+ — verify total updates after first page loads
- [ ] Run a SELECT on Oracle — verify no new JDBC connection opened per query
- [ ] Verify diagnostics appear in tech log
- [ ] Verify cell selection, Cmd+C copy, and cell detail panel work

🤖 Generated with [Claude Code](https://claude.com/claude-code)