### PR TITLE
fix: reset grid selection on query run and cross-clear cell/row

### DIFF
--- a/src/features/query/QueryWorkspace.tsx
+++ b/src/features/query/QueryWorkspace.tsx
@@ -217,6 +217,7 @@ export default function QueryWorkspace() {
   const [pendingRowEdits, setPendingRowEdits] = useState<Map<object, Record<string, string | null>>>(new Map());
   const [pendingNewRows, setPendingNewRows] = useState<Record<string, unknown>[]>([]);
   const [focusNewRowToken, setFocusNewRowToken] = useState(0);
+  const [gridClearSelectionToken, setGridClearSelectionToken] = useState(0);
   const [historyRefreshToken, setHistoryRefreshToken] = useState(0);
   const [gridFullscreen, setGridFullscreen] = useState(false);
   const [resultsCollapsed, setResultsCollapsed] = useState(false);
@@ -418,6 +419,8 @@ export default function QueryWorkspace() {
       setTabError(activeTabId, null);
       setActivePanel('results');
       setResultsCollapsed(false);
+      setSelectedSourceRowIndex(null);
+      setGridClearSelectionToken((t) => t + 1);
     });
     return window.performance.now();
   }, [activeTabId, setSemanticBackgroundState, setTabError]);
@@ -1252,6 +1255,7 @@ export default function QueryWorkspace() {
 
   useEffect(() => {
     setSelectedSourceRowIndex(null);
+    setGridClearSelectionToken((t) => t + 1);
     setPendingRowEdits(new Map());
     setPendingNewRows([]);
   }, [activeResultIndex, resolvedConnectionId, activeResult?.statement, activeTabId]);
@@ -1498,6 +1502,7 @@ export default function QueryWorkspace() {
     }
 
     setSelectedSourceRowIndex((current) => (current === sourceIndex ? null : sourceIndex));
+    setGridClearSelectionToken((t) => t + 1);
   }, [activeResult]);
 
   const handleDeleteSelectedRow = useCallback(async () => {
@@ -2087,6 +2092,8 @@ export default function QueryWorkspace() {
                   focusNewRowToken={canEditGrid ? focusNewRowToken : undefined}
                   selectedRowIndex={selectedDisplayRowIndex}
                   onRowSelect={handleRowSelect}
+                  onCellFocused={() => setSelectedSourceRowIndex(null)}
+                  clearSelectionToken={gridClearSelectionToken}
                 />
               ) : activeResult.summary ? null : (
                 <div className="h-full flex items-center justify-center text-muted/50 text-sm">

--- a/src/features/query/ResultGrid.tsx
+++ b/src/features/query/ResultGrid.tsx
@@ -22,6 +22,8 @@ interface ResultGridProps {
   onRowSelect?: (rowIndex: number, row: Record<string, unknown>) => void;
   layoutKey?: string | null;
   onFocusQuickFilter?: () => void;
+  onCellFocused?: () => void;
+  clearSelectionToken?: number;
   accentColor?: string;
 }
 
@@ -38,6 +40,8 @@ export default function ResultGrid({
   onRowSelect,
   layoutKey = null,
   onFocusQuickFilter,
+  onCellFocused,
+  clearSelectionToken,
   accentColor = '#38bdf8',
 }: ResultGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
@@ -241,6 +245,13 @@ export default function ResultGrid({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusNewRowToken]);
 
+  useEffect(() => {
+    if (clearSelectionToken === undefined) return;
+    setSelectedCell(null);
+    setSelectionAnchor(null);
+    setDetailCell(null);
+  }, [clearSelectionToken]);
+
   const anyEditActive = activeEditCell !== null;
 
   const lockedRowIndex = (() => {
@@ -297,6 +308,7 @@ export default function ResultGrid({
       setSelectionAnchor({ rowIndex, column: colName });
     }
     setSelectedCell({ rowIndex, column: colName });
+    onCellFocused?.();
     parentRef.current?.focus();
   };
 

--- a/src/features/settings/ConfigurationDialog.tsx
+++ b/src/features/settings/ConfigurationDialog.tsx
@@ -848,14 +848,6 @@ export default function ConfigurationDialog({
           )}
         </div>
 
-        {/* Preview notice */}
-        <div
-          className="mx-5 mb-3 rounded-lg border px-3.5 py-2.5 text-[11px] leading-relaxed"
-          style={{ background: hexToRgba(cc, 0.06), borderColor: hexToRgba(cc, 0.22), color: hexToRgba(cc, 0.75) }}
-        >
-          Algumas funcionalidades ainda são visuais. A implementação completa está em andamento e será entregue em breve.
-        </div>
-
         {/* Footer */}
         <div className="flex items-center gap-3 border-t border-border px-5 py-4">
           <div


### PR DESCRIPTION
## Summary

- Running a query immediately clears both cell and row selection (via `startExecutionFeedback`)
- Clicking a cell clears the selected row; clicking a row clears the selected cell
- Remove duplicate preview notice from ConfigurationDialog (was appearing twice after branch merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)