### PR TITLE
fix: include autocomplete module files missing from v0.3.1

### DIFF
--- a/src/features/query/autocomplete/sqlAliasParser.ts
+++ b/src/features/query/autocomplete/sqlAliasParser.ts
@@ -1,0 +1,87 @@
+export interface SqlTableReference {
+  schemaName?: string;
+  tableName: string;
+  tableRef: string;
+  alias?: string;
+}
+
+export interface SqlAliasTarget extends SqlTableReference {
+  alias: string;
+}
+
+export interface ParsedSqlAliases {
+  aliases: Map<string, SqlAliasTarget>;
+  tables: SqlTableReference[];
+}
+
+const SQL_KEYWORDS = new Set([
+  'and',
+  'as',
+  'cross',
+  'full',
+  'group',
+  'having',
+  'inner',
+  'join',
+  'left',
+  'limit',
+  'on',
+  'order',
+  'right',
+  'where',
+]);
+
+const IDENTIFIER = String.raw`(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)`;
+const TABLE_REFERENCE_PATTERN = new RegExp(
+  String.raw`\b(?:from|join)\s+(${IDENTIFIER}(?:\.${IDENTIFIER})?)(?:\s+(?:as\s+)?(${IDENTIFIER}))?`,
+  'gi',
+);
+
+export function parseSimpleAliases(sqlText: string): ParsedSqlAliases {
+  const aliases = new Map<string, SqlAliasTarget>();
+  const tables: SqlTableReference[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = TABLE_REFERENCE_PATTERN.exec(sqlText)) !== null) {
+    const tableRef = normalizeIdentifier(match[1] ?? '');
+    const alias = normalizeIdentifier(match[2] ?? '');
+
+    if (!tableRef) {
+      continue;
+    }
+
+    const parts = tableRef.split('.');
+    const tableName = parts[parts.length - 1] ?? tableRef;
+    const schemaName = parts.length > 1 ? parts[parts.length - 2] : undefined;
+    const table: SqlTableReference = {
+      schemaName,
+      tableName,
+      tableRef,
+      alias: isValidAlias(alias) ? alias : undefined,
+    };
+
+    tables.push(table);
+
+    if (table.alias) {
+      aliases.set(table.alias.toLowerCase(), {
+        ...table,
+        alias: table.alias,
+      });
+    }
+  }
+
+  return { aliases, tables };
+}
+
+function normalizeIdentifier(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+}
+
+function isValidAlias(value: string): boolean {
+  return Boolean(value) && !SQL_KEYWORDS.has(value.toLowerCase());
+}

--- a/src/features/query/autocomplete/sqlAutocompleteContext.ts
+++ b/src/features/query/autocomplete/sqlAutocompleteContext.ts
@@ -1,0 +1,268 @@
+import type * as Monaco from 'monaco-editor';
+import { parseSimpleAliases, type ParsedSqlAliases } from './sqlAliasParser';
+
+export type SqlAutocompleteContextKind =
+  | 'afterSelectKeyword'
+  | 'afterFromKeyword'
+  | 'afterJoinKeyword'
+  | 'afterDot'
+  | 'afterWhereKeyword'
+  | 'afterOrderByKeyword'
+  | 'afterGroupByKeyword'
+  | 'selectWithFrom'
+  | 'generic';
+
+export interface SqlAutocompleteContext {
+  aliases: ParsedSqlAliases;
+  currentStatement: string;
+  currentStatementBeforeCursor: string;
+  dotObject?: string;
+  dotPartial?: string;
+  kind: SqlAutocompleteContextKind;
+  replacementRange: Monaco.IRange;
+  selectTemplateRange: Monaco.IRange;
+  textBeforeCursor: string;
+  typedToken: string;
+  wordRange: Monaco.IRange;
+}
+
+interface StatementBounds {
+  beforeCursor: string;
+  fullStatement: string;
+  startOffset: number;
+}
+
+interface KeywordMatch {
+  index: number;
+  kind: SqlAutocompleteContextKind;
+}
+
+export function getSqlAutocompleteContext(
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+): SqlAutocompleteContext {
+  const bounds = getCurrentStatementBounds(model, position);
+  const word = model.getWordUntilPosition(position);
+  const wordRange = {
+    startLineNumber: position.lineNumber,
+    startColumn: word.startColumn,
+    endLineNumber: position.lineNumber,
+    endColumn: word.endColumn,
+  };
+  const selectTemplateStartOffset =
+    bounds.startOffset + (bounds.beforeCursor.match(/^\s*/)?.[0].length ?? 0);
+  const selectTemplateRange = buildRangeFromOffsets(
+    model,
+    selectTemplateStartOffset,
+    model.getOffsetAt(position),
+  );
+  const aliases = parseSimpleAliases(bounds.fullStatement);
+  const base = {
+    aliases,
+    currentStatement: bounds.fullStatement,
+    currentStatementBeforeCursor: bounds.beforeCursor,
+    selectTemplateRange,
+    textBeforeCursor: bounds.beforeCursor,
+    typedToken: word.word,
+    wordRange,
+  };
+
+  const tableContext = matchTableContext(bounds.beforeCursor, model, position);
+  if (tableContext) {
+    return {
+      ...base,
+      kind: tableContext.keyword === 'join' ? 'afterJoinKeyword' : 'afterFromKeyword',
+      replacementRange: tableContext.replacementRange,
+      typedToken: tableContext.typedToken,
+    };
+  }
+
+  const dotContext = matchDotContext(bounds.beforeCursor);
+  if (dotContext) {
+    return {
+      ...base,
+      dotObject: dotContext.objectRef,
+      dotPartial: dotContext.partial,
+      kind: 'afterDot',
+      replacementRange: buildRange(position, dotContext.partial.length),
+      typedToken: dotContext.partial,
+    };
+  }
+
+  const bareSelect = matchBareSelect(bounds.beforeCursor);
+  if (bareSelect) {
+    if (/\bfrom\b/i.test(bounds.fullStatement)) {
+      return {
+        ...base,
+        kind: 'selectWithFrom',
+        replacementRange: wordRange,
+        typedToken: word.word,
+      };
+    }
+
+    return {
+      ...base,
+      kind: 'afterSelectKeyword',
+      replacementRange: selectTemplateRange,
+      typedToken: bareSelect.typedToken,
+    };
+  }
+
+  const columnKeyword = findColumnKeywordContext(bounds.beforeCursor);
+  if (columnKeyword && /\bfrom\b/i.test(bounds.fullStatement)) {
+    return {
+      ...base,
+      kind: columnKeyword.kind,
+      replacementRange: wordRange,
+      typedToken: word.word,
+    };
+  }
+
+  return {
+    ...base,
+    kind: 'generic',
+    replacementRange: wordRange,
+  };
+}
+
+export function isTableSuggestionContext(sqlBeforeCursor: string): boolean {
+  const statement = getStatementBeforeCursor(sqlBeforeCursor);
+  const tableMatch = statement.match(/\b(?:from|join)\s+([A-Za-z0-9_$."`]*)$/i);
+  return Boolean(matchBareSelect(statement) || (tableMatch?.[1]?.length ?? 0) > 0);
+}
+
+function getCurrentStatementBounds(
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+): StatementBounds {
+  const fullText = model.getValue();
+  const offset = model.getOffsetAt(position);
+  const startOffset = fullText.lastIndexOf(';', Math.max(0, offset - 1)) + 1;
+  const nextSemicolon = fullText.indexOf(';', offset);
+  const endOffset = nextSemicolon >= 0 ? nextSemicolon : fullText.length;
+
+  return {
+    beforeCursor: fullText.slice(startOffset, offset),
+    fullStatement: fullText.slice(startOffset, endOffset),
+    startOffset,
+  };
+}
+
+function getStatementBeforeCursor(sqlBeforeCursor: string): string {
+  const lastSemicolon = sqlBeforeCursor.lastIndexOf(';');
+  return sqlBeforeCursor.slice(lastSemicolon + 1);
+}
+
+function matchBareSelect(statementBeforeCursor: string): { typedToken: string } | null {
+  const match = statementBeforeCursor.match(/^\s*select(?:\s+([A-Za-z0-9_$."`]*))?$/i);
+  if (!match) {
+    return null;
+  }
+
+  return { typedToken: match[1] ?? '' };
+}
+
+function matchTableContext(
+  statementBeforeCursor: string,
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+): { keyword: 'from' | 'join'; replacementRange: Monaco.IRange; typedToken: string } | null {
+  const match = statementBeforeCursor.match(/\b(from|join)\s+([A-Za-z0-9_$."`]*)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const typedToken = match[2] ?? '';
+  const endOffset = model.getOffsetAt(position);
+  const startOffset = Math.max(0, endOffset - typedToken.length);
+
+  return {
+    keyword: (match[1] ?? 'from').toLowerCase() === 'join' ? 'join' : 'from',
+    replacementRange: buildRangeFromOffsets(model, startOffset, endOffset),
+    typedToken,
+  };
+}
+
+function matchDotContext(statementBeforeCursor: string): { objectRef: string; partial: string } | null {
+  const match = statementBeforeCursor.match(/([A-Za-z_][A-Za-z0-9_$]*(?:\.[A-Za-z_][A-Za-z0-9_$]*)?)\.([A-Za-z0-9_$]*)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    objectRef: match[1] ?? '',
+    partial: match[2] ?? '',
+  };
+}
+
+function findColumnKeywordContext(statementBeforeCursor: string): KeywordMatch | null {
+  const matches: KeywordMatch[] = [
+    ...findKeywordMatches(statementBeforeCursor, /\border\s+by\b/gi, 'afterOrderByKeyword'),
+    ...findKeywordMatches(statementBeforeCursor, /\bgroup\s+by\b/gi, 'afterGroupByKeyword'),
+    ...findKeywordMatches(statementBeforeCursor, /\bwhere\b/gi, 'afterWhereKeyword'),
+    ...findKeywordMatches(statementBeforeCursor, /\b(?:select|having|on|and|or|set)\b/gi, 'selectWithFrom'),
+  ];
+
+  if (!matches.length) {
+    return null;
+  }
+
+  const lastColumnKeyword = matches.sort((left, right) => right.index - left.index)[0];
+  const lastTableKeywordIndex = findLastKeywordIndex(statementBeforeCursor, /\b(?:from|join)\b/gi);
+  if (lastTableKeywordIndex > lastColumnKeyword.index) {
+    return null;
+  }
+
+  return lastColumnKeyword;
+}
+
+function findKeywordMatches(
+  text: string,
+  pattern: RegExp,
+  kind: SqlAutocompleteContextKind,
+): KeywordMatch[] {
+  const matches: KeywordMatch[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    matches.push({ index: match.index, kind });
+  }
+
+  return matches;
+}
+
+function findLastKeywordIndex(text: string, pattern: RegExp): number {
+  let lastIndex = -1;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    lastIndex = match.index;
+  }
+
+  return lastIndex;
+}
+
+function buildRange(position: Monaco.Position, tokenLength: number): Monaco.IRange {
+  return {
+    startLineNumber: position.lineNumber,
+    startColumn: Math.max(1, position.column - tokenLength),
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  };
+}
+
+function buildRangeFromOffsets(
+  model: Monaco.editor.ITextModel,
+  startOffset: number,
+  endOffset: number,
+): Monaco.IRange {
+  const start = model.getPositionAt(startOffset);
+  const end = model.getPositionAt(endOffset);
+
+  return {
+    startLineNumber: start.lineNumber,
+    startColumn: start.column,
+    endLineNumber: end.lineNumber,
+    endColumn: end.column,
+  };
+}

--- a/src/features/query/autocomplete/sqlAutocompleteProvider.ts
+++ b/src/features/query/autocomplete/sqlAutocompleteProvider.ts
@@ -1,0 +1,611 @@
+import type * as Monaco from 'monaco-editor';
+import type { DatabaseEngine } from '../../../store/connections';
+import { useDatabaseSessionStore } from '../../../store/databaseSession';
+import type { MetadataColumn, MetadataConnectionEntry } from '../../database/types';
+import {
+  getSqlAutocompleteContext,
+  type SqlAutocompleteContext,
+} from './sqlAutocompleteContext';
+import type { ParsedSqlAliases, SqlTableReference } from './sqlAliasParser';
+import { makeSortText, rankSqlTableCandidates, type RankableSqlCandidate } from './sqlAutocompleteRanking';
+import { SELECT_FROM_TABLE_SNIPPET, SQL_KEYWORDS } from './sqlSnippets';
+
+interface SqlAutocompleteRuntimeContext {
+  connectionId?: string | null;
+  activeSchema?: string | null;
+  engine?: DatabaseEngine | null;
+}
+
+interface BuildSuggestionsParams {
+  activeSchema?: string | null;
+  completionContext?: Monaco.languages.CompletionContext;
+  metadata?: MetadataConnectionEntry;
+}
+
+interface SqlTableCandidate extends RankableSqlCandidate {
+  insertText: string;
+  schemaName: string;
+}
+
+interface ResolvedTableReference {
+  schemaName: string;
+  tableName: string;
+}
+
+export function registerSqlAutocomplete(
+  monaco: typeof Monaco,
+  getContext: () => SqlAutocompleteRuntimeContext,
+) {
+  return monaco.languages.registerCompletionItemProvider('sql', {
+    triggerCharacters: ['.', ' ', '\n', '_'],
+    provideCompletionItems(model, position, completionContext) {
+      const startedAt = performance.now();
+      const runtimeContext = getContext();
+      const metadata = runtimeContext.connectionId
+        ? useDatabaseSessionStore.getState().metadataByConnection[runtimeContext.connectionId]
+        : undefined;
+      const activeSchema = resolveActiveSchema(
+        metadata,
+        runtimeContext.connectionId,
+        runtimeContext.activeSchema,
+      );
+      const sqlContext = getSqlAutocompleteContext(model, position);
+      const suggestions = buildSuggestions(monaco, sqlContext, {
+        activeSchema,
+        completionContext,
+        metadata,
+      });
+
+      logAutocompleteDebug(sqlContext, suggestions.length, performance.now() - startedAt);
+
+      return {
+        suggestions,
+        incomplete: shouldRequeryAutocomplete(sqlContext),
+      };
+    },
+  });
+}
+
+export function buildSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams = {},
+): Monaco.languages.CompletionItem[] {
+  switch (context.kind) {
+    case 'afterSelectKeyword':
+      return buildAfterSelectSuggestions(monaco, context, params);
+    case 'afterFromKeyword':
+    case 'afterJoinKeyword':
+      return buildTableReferenceSuggestions(monaco, context, params);
+    case 'afterDot':
+      return buildDotColumnSuggestions(monaco, context, params);
+    case 'afterWhereKeyword':
+    case 'afterOrderByKeyword':
+    case 'afterGroupByKeyword':
+    case 'selectWithFrom':
+      return buildStatementColumnSuggestions(monaco, context, params);
+    case 'generic':
+      return buildGenericSuggestions(monaco, context, params);
+    default:
+      return [];
+  }
+}
+
+export function getColumnsForAlias(
+  alias: string,
+  metadata: MetadataConnectionEntry | undefined,
+  activeSchema: string | null | undefined,
+  aliases: ParsedSqlAliases,
+): Array<{ column: MetadataColumn; tableLabel: string }> {
+  return getColumnsForObjectRef(alias, metadata, activeSchema, aliases);
+}
+
+function buildAfterSelectSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams,
+): Monaco.languages.CompletionItem[] {
+  const tableCandidates = rankSqlTableCandidates(
+    collectTableCandidates(params.metadata, params.activeSchema, false),
+    context.typedToken,
+  );
+
+  if (tableCandidates.length) {
+    const filterText = context.typedToken || 'select';
+    return tableCandidates
+      .slice(0, 80)
+      .map((candidate, index) =>
+        buildConcreteSelectSuggestion(monaco, candidate, context.selectTemplateRange, index, filterText),
+      );
+  }
+
+  const suggestions: Monaco.languages.CompletionItem[] = [
+    buildSelectTemplateSuggestion(monaco, context.selectTemplateRange),
+    ...buildKeywordSuggestions(monaco, context.wordRange, 80),
+  ];
+
+  return dedupeSuggestions(suggestions);
+}
+
+function buildTableReferenceSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams,
+): Monaco.languages.CompletionItem[] {
+  const preferQualified = context.typedToken.includes('.');
+  const tableCandidates = rankSqlTableCandidates(
+    collectTableCandidates(params.metadata, params.activeSchema, preferQualified),
+    context.typedToken,
+  );
+
+  if (!tableCandidates.length) {
+    return isManualTrigger(monaco, params)
+      ? buildKeywordSuggestions(monaco, context.replacementRange, 80)
+      : [];
+  }
+
+  const suggestionLimit = context.typedToken ? 200 : 80;
+
+  return tableCandidates
+    .slice(0, suggestionLimit)
+    .map((candidate, index) =>
+      buildTableSuggestion(monaco, candidate, context.replacementRange, index, context.typedToken),
+    );
+}
+
+function buildDotColumnSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams,
+): Monaco.languages.CompletionItem[] {
+  const columns = getColumnsForObjectRef(
+    context.dotObject ?? '',
+    params.metadata,
+    params.activeSchema,
+    context.aliases,
+  );
+  const normalizedPartial = context.dotPartial?.toLowerCase() ?? '';
+
+  return columns
+    .filter(({ column }) =>
+      normalizedPartial
+        ? column.columnName.toLowerCase().startsWith(normalizedPartial)
+        : true,
+    )
+    .slice(0, 80)
+    .map(({ column, tableLabel }, index) =>
+      buildColumnSuggestion(monaco, column, tableLabel, context.replacementRange, index),
+    );
+}
+
+function buildStatementColumnSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams,
+): Monaco.languages.CompletionItem[] {
+  const columns = collectStatementColumns(params.metadata, params.activeSchema, context.aliases);
+  const normalizedToken = context.typedToken.toLowerCase();
+  const seen = new Set<string>();
+  const columnSuggestions = columns
+    .filter(({ column }) => {
+      const key = column.columnName.toLowerCase();
+      if (seen.has(key)) {
+        return false;
+      }
+
+      if (normalizedToken && !key.startsWith(normalizedToken)) {
+        return false;
+      }
+
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 80)
+    .map(({ column, tableLabel }, index) =>
+      buildColumnSuggestion(monaco, column, tableLabel, context.replacementRange, index),
+    );
+
+  return dedupeSuggestions([
+    ...columnSuggestions,
+    ...buildKeywordSuggestions(monaco, context.replacementRange, 80),
+  ]);
+}
+
+function buildGenericSuggestions(
+  monaco: typeof Monaco,
+  context: SqlAutocompleteContext,
+  params: BuildSuggestionsParams,
+): Monaco.languages.CompletionItem[] {
+  const typedToken = context.typedToken.trim();
+
+  if (!isManualTrigger(monaco, params) && typedToken.length < 2) {
+    return [];
+  }
+
+  const tableSuggestions = rankSqlTableCandidates(
+    collectTableCandidates(params.metadata, params.activeSchema, false),
+    typedToken,
+  )
+    .slice(0, 40)
+    .map((candidate, index) =>
+      buildTableSuggestion(monaco, candidate, context.replacementRange, index, typedToken),
+    );
+
+  return dedupeSuggestions([
+    ...tableSuggestions,
+    ...buildKeywordSuggestions(monaco, context.replacementRange, 80),
+  ]);
+}
+
+function isManualTrigger(
+  monaco: typeof Monaco,
+  params: BuildSuggestionsParams,
+): boolean {
+  return params.completionContext?.triggerKind === monaco.languages.CompletionTriggerKind.Invoke;
+}
+
+function shouldRequeryAutocomplete(context: SqlAutocompleteContext): boolean {
+  return (
+    context.kind === 'afterFromKeyword' ||
+    context.kind === 'afterJoinKeyword' ||
+    context.kind === 'afterSelectKeyword' ||
+    context.kind === 'generic'
+  );
+}
+
+function collectTableCandidates(
+  metadata: MetadataConnectionEntry | undefined,
+  activeSchema: string | null | undefined,
+  preferQualified: boolean,
+): SqlTableCandidate[] {
+  if (!metadata) {
+    return [];
+  }
+
+  const candidates: SqlTableCandidate[] = [];
+  const seen = new Set<string>();
+  const resolvedActiveSchema = resolveSchemaName(metadata, activeSchema);
+  const schemaNames = metadata.schemas.length ? metadata.schemas : Object.keys(metadata.schemasByName);
+
+  const pushTables = (schemaName: string, isActiveSchema: boolean) => {
+    const schemaEntry = metadata.schemasByName[schemaName];
+    if (!schemaEntry) {
+      return;
+    }
+
+    for (const tableName of schemaEntry.tables) {
+      const qualifiedName = `${schemaName}.${tableName}`;
+      const key = preferQualified
+        ? qualifiedName.toLowerCase()
+        : tableName.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      candidates.push({
+        insertText: preferQualified ? qualifiedName : tableName,
+        isActiveSchema,
+        qualifiedName,
+        schemaName,
+        sourceOrder: candidates.length,
+        tableName,
+      });
+    }
+  };
+
+  if (resolvedActiveSchema) {
+    pushTables(resolvedActiveSchema, true);
+  }
+
+  for (const schemaName of schemaNames) {
+    if (schemaName === resolvedActiveSchema) {
+      continue;
+    }
+
+    pushTables(schemaName, false);
+  }
+
+  return candidates;
+}
+
+function collectStatementColumns(
+  metadata: MetadataConnectionEntry | undefined,
+  activeSchema: string | null | undefined,
+  aliases: ParsedSqlAliases,
+): Array<{ column: MetadataColumn; tableLabel: string }> {
+  return aliases.tables
+    .slice(0, 6)
+    .flatMap((tableRef) => getColumnsForTableReference(tableRef, metadata, activeSchema));
+}
+
+function getColumnsForObjectRef(
+  objectRef: string,
+  metadata: MetadataConnectionEntry | undefined,
+  activeSchema: string | null | undefined,
+  aliases: ParsedSqlAliases,
+): Array<{ column: MetadataColumn; tableLabel: string }> {
+  if (!metadata || !objectRef) {
+    return [];
+  }
+
+  const aliasTarget = aliases.aliases.get(objectRef.toLowerCase());
+  if (aliasTarget) {
+    return getColumnsForTableReference(aliasTarget, metadata, activeSchema);
+  }
+
+  const directTable = resolveObjectRefAsTable(metadata, activeSchema, objectRef);
+  if (!directTable) {
+    return [];
+  }
+
+  return getColumnsForResolvedTable(metadata, directTable);
+}
+
+function getColumnsForTableReference(
+  tableRef: SqlTableReference,
+  metadata: MetadataConnectionEntry | undefined,
+  activeSchema: string | null | undefined,
+): Array<{ column: MetadataColumn; tableLabel: string }> {
+  if (!metadata) {
+    return [];
+  }
+
+  const resolvedSchema = resolveSchemaName(metadata, tableRef.schemaName ?? activeSchema);
+  if (resolvedSchema) {
+    const resolvedTable = resolveTableName(metadata, resolvedSchema, tableRef.tableName);
+    if (resolvedTable) {
+      return getColumnsForResolvedTable(metadata, {
+        schemaName: resolvedSchema,
+        tableName: resolvedTable,
+      });
+    }
+  }
+
+  const fallbackTable = resolveObjectRefAsTable(metadata, activeSchema, tableRef.tableName);
+  return fallbackTable ? getColumnsForResolvedTable(metadata, fallbackTable) : [];
+}
+
+function getColumnsForResolvedTable(
+  metadata: MetadataConnectionEntry,
+  table: ResolvedTableReference,
+): Array<{ column: MetadataColumn; tableLabel: string }> {
+  const columns =
+    metadata.schemasByName[table.schemaName]?.tablesByName[table.tableName]?.columns ?? [];
+  const tableLabel = `${table.schemaName}.${table.tableName}`;
+
+  return columns.map((column) => ({ column, tableLabel }));
+}
+
+function resolveObjectRefAsTable(
+  metadata: MetadataConnectionEntry,
+  activeSchema: string | null | undefined,
+  objectRef: string,
+): ResolvedTableReference | null {
+  const parts = objectRef.split('.');
+
+  if (parts.length >= 2) {
+    const schemaName = resolveSchemaName(metadata, parts[parts.length - 2]);
+    if (!schemaName) {
+      return null;
+    }
+
+    const tableName = resolveTableName(metadata, schemaName, parts[parts.length - 1] ?? '');
+    return tableName ? { schemaName, tableName } : null;
+  }
+
+  const activeSchemaName = resolveSchemaName(metadata, activeSchema);
+  if (activeSchemaName) {
+    const activeTableName = resolveTableName(metadata, activeSchemaName, objectRef);
+    if (activeTableName) {
+      return { schemaName: activeSchemaName, tableName: activeTableName };
+    }
+  }
+
+  for (const schemaName of metadata.schemas.length ? metadata.schemas : Object.keys(metadata.schemasByName)) {
+    const tableName = resolveTableName(metadata, schemaName, objectRef);
+    if (tableName) {
+      return { schemaName, tableName };
+    }
+  }
+
+  return null;
+}
+
+function buildSelectTemplateSuggestion(
+  monaco: typeof Monaco,
+  range: Monaco.IRange,
+): Monaco.languages.CompletionItem {
+  return {
+    label: SELECT_FROM_TABLE_SNIPPET.label,
+    kind: monaco.languages.CompletionItemKind.Snippet,
+    detail: SELECT_FROM_TABLE_SNIPPET.detail,
+    filterText: 'select',
+    insertText: SELECT_FROM_TABLE_SNIPPET.insertText,
+    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    range,
+    sortText: '00_select_template',
+  };
+}
+
+function buildConcreteSelectSuggestion(
+  monaco: typeof Monaco,
+  candidate: SqlTableCandidate,
+  range: Monaco.IRange,
+  index: number,
+  typedToken: string,
+): Monaco.languages.CompletionItem {
+  return {
+    label: {
+      label: candidate.tableName,
+      description: candidate.schemaName,
+    },
+    kind: monaco.languages.CompletionItemKind.Struct,
+    detail: `SELECT * FROM ${candidate.insertText}`,
+    filterText: typedToken || candidate.tableName,
+    insertText: `SELECT * FROM ${candidate.insertText};`,
+    range,
+    sortText: makeSortText(1, index, candidate.qualifiedName),
+  };
+}
+
+function buildTableSuggestion(
+  monaco: typeof Monaco,
+  candidate: SqlTableCandidate,
+  range: Monaco.IRange,
+  index: number,
+  typedToken: string,
+): Monaco.languages.CompletionItem {
+  return {
+    label: {
+      label: candidate.tableName,
+      description: candidate.schemaName,
+    },
+    kind: monaco.languages.CompletionItemKind.Struct,
+    detail: `table - ${candidate.schemaName}`,
+    filterText: typedToken || candidate.tableName,
+    insertText: candidate.insertText,
+    range,
+    sortText: makeSortText(candidate.isActiveSchema ? 20 : 90, index, candidate.qualifiedName),
+  };
+}
+
+function buildColumnSuggestion(
+  monaco: typeof Monaco,
+  column: MetadataColumn,
+  tableLabel: string,
+  range: Monaco.IRange,
+  index: number,
+): Monaco.languages.CompletionItem {
+  return {
+    label: {
+      label: column.columnName,
+      description: column.dataType,
+    },
+    kind: monaco.languages.CompletionItemKind.Field,
+    detail: `${column.dataType}${column.nullable === false ? ' NOT NULL' : ''} - ${tableLabel}`,
+    filterText: column.columnName,
+    insertText: column.columnName,
+    range,
+    sortText: makeSortText(10, index, column.columnName),
+  };
+}
+
+function buildKeywordSuggestions(
+  monaco: typeof Monaco,
+  range: Monaco.IRange,
+  bucket: number,
+): Monaco.languages.CompletionItem[] {
+  return SQL_KEYWORDS.map((keyword, index) => ({
+    label: keyword.label,
+    kind: monaco.languages.CompletionItemKind.Keyword,
+    detail: 'SQL keyword',
+    insertText: keyword.insertText,
+    range,
+    sortText: makeSortText(bucket, index, keyword.label),
+  }));
+}
+
+function dedupeSuggestions(
+  suggestions: Monaco.languages.CompletionItem[],
+): Monaco.languages.CompletionItem[] {
+  const seen = new Set<string>();
+  const unique: Monaco.languages.CompletionItem[] = [];
+
+  for (const suggestion of suggestions) {
+    const key = `${labelToString(suggestion.label)}:${suggestion.detail ?? ''}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(suggestion);
+  }
+
+  return unique;
+}
+
+function labelToString(label: Monaco.languages.CompletionItem['label']): string {
+  return typeof label === 'string' ? label : label.label;
+}
+
+function resolveActiveSchema(
+  metadata: MetadataConnectionEntry | undefined,
+  connectionId: string | null | undefined,
+  activeSchema: string | null | undefined,
+): string | null {
+  const schemaName =
+    activeSchema ??
+    (connectionId ? useDatabaseSessionStore.getState().activeSchemaByConnection[connectionId] : null);
+
+  return resolveSchemaName(metadata, schemaName);
+}
+
+function resolveSchemaName(
+  metadata: MetadataConnectionEntry | undefined,
+  schemaName: string | null | undefined,
+): string | null {
+  if (!metadata || !schemaName) {
+    return null;
+  }
+
+  if (metadata.schemasByName[schemaName]) {
+    return schemaName;
+  }
+
+  return (
+    Object.keys(metadata.schemasByName).find(
+      (candidate) => candidate.toLowerCase() === schemaName.toLowerCase(),
+    ) ?? null
+  );
+}
+
+function resolveTableName(
+  metadata: MetadataConnectionEntry,
+  schemaName: string,
+  tableName: string,
+): string | null {
+  const tablesByName = metadata.schemasByName[schemaName]?.tablesByName;
+  if (!tablesByName) {
+    return null;
+  }
+
+  if (tablesByName[tableName]) {
+    return tableName;
+  }
+
+  return (
+    Object.keys(tablesByName).find(
+      (candidate) => candidate.toLowerCase() === tableName.toLowerCase(),
+    ) ?? null
+  );
+}
+
+function logAutocompleteDebug(
+  context: SqlAutocompleteContext,
+  suggestionCount: number,
+  durationMs: number,
+) {
+  if (!isAutocompleteDebugEnabled()) {
+    return;
+  }
+
+  console.debug('[PulseSQL autocomplete]', {
+    context: context.kind,
+    durationMs: Math.round(durationMs),
+    suggestions: suggestionCount,
+    typedToken: context.typedToken,
+  });
+}
+
+function isAutocompleteDebugEnabled(): boolean {
+  if (!import.meta.env.DEV) {
+    return false;
+  }
+
+  try {
+    return localStorage.getItem('pulsesql:debug-autocomplete') === '1';
+  } catch {
+    return false;
+  }
+}

--- a/src/features/query/autocomplete/sqlAutocompleteRanking.ts
+++ b/src/features/query/autocomplete/sqlAutocompleteRanking.ts
@@ -1,0 +1,91 @@
+export interface RankableSqlCandidate {
+  isActiveSchema?: boolean;
+  qualifiedName: string;
+  sourceOrder: number;
+  tableName: string;
+}
+
+export function rankSqlTableCandidates<T extends RankableSqlCandidate>(
+  candidates: T[],
+  typedToken: string,
+): T[] {
+  const normalizedToken = normalizeSearchValue(typedToken);
+
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      score: scoreTableCandidate(candidate, normalizedToken),
+    }))
+    .filter((entry) => entry.score < Number.POSITIVE_INFINITY)
+    .sort((left, right) => {
+      const activeSchemaDelta = Number(!left.candidate.isActiveSchema) - Number(!right.candidate.isActiveSchema);
+      return (
+        left.score - right.score ||
+        activeSchemaDelta ||
+        left.candidate.sourceOrder - right.candidate.sourceOrder ||
+        left.candidate.qualifiedName.localeCompare(right.candidate.qualifiedName)
+      );
+    })
+    .map((entry) => entry.candidate);
+}
+
+export function makeSortText(bucket: number, index: number, label: string): string {
+  return `${String(bucket).padStart(2, '0')}_${String(index).padStart(4, '0')}_${label.toLowerCase()}`;
+}
+
+function scoreTableCandidate(candidate: RankableSqlCandidate, normalizedToken: string): number {
+  if (!normalizedToken) {
+    return 0;
+  }
+
+  const tableName = normalizeSearchValue(candidate.tableName);
+  const qualifiedName = normalizeSearchValue(candidate.qualifiedName);
+  const activePenalty = candidate.isActiveSchema ? 0 : 20;
+  const segmentStartIndex = findSegmentStartIndex(tableName, normalizedToken);
+  const tableIncludesIndex = tableName.indexOf(normalizedToken);
+  const qualifiedIncludesIndex = qualifiedName.indexOf(normalizedToken);
+
+  if (tableName.startsWith(normalizedToken)) {
+    return activePenalty;
+  }
+
+  if (qualifiedName.startsWith(normalizedToken)) {
+    return activePenalty + 1;
+  }
+
+  if (segmentStartIndex >= 0) {
+    return activePenalty + 2 + Math.min(segmentStartIndex, 50) / 100;
+  }
+
+  if (qualifiedName.includes(`.${normalizedToken}`)) {
+    return activePenalty + 3;
+  }
+
+  if (tableIncludesIndex >= 0) {
+    return activePenalty + 4 + Math.min(tableIncludesIndex, 50) / 100;
+  }
+
+  if (qualifiedIncludesIndex >= 0) {
+    return activePenalty + 5 + Math.min(qualifiedIncludesIndex, 50) / 100;
+  }
+
+  return Number.POSITIVE_INFINITY;
+}
+
+function normalizeSearchValue(value: string): string {
+  return value.trim().replace(/^["`]+|["`]+$/g, '').toLowerCase();
+}
+
+function findSegmentStartIndex(value: string, token: string): number {
+  const pattern = new RegExp(`(?:^|[_.$])${escapeRegExp(token)}`);
+  const match = pattern.exec(value);
+  if (!match) {
+    return -1;
+  }
+
+  return match[0].startsWith(token) ? match.index : match.index + 1;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/features/query/autocomplete/sqlSnippets.ts
+++ b/src/features/query/autocomplete/sqlSnippets.ts
@@ -1,0 +1,25 @@
+export interface SqlKeywordDefinition {
+  label: string;
+  insertText: string;
+}
+
+export const SELECT_FROM_TABLE_SNIPPET = {
+  label: 'SELECT * FROM table',
+  detail: 'Template',
+  insertText: 'SELECT * FROM ${1:table_name};$0',
+};
+
+export const SQL_KEYWORDS: SqlKeywordDefinition[] = [
+  { label: 'SELECT', insertText: 'SELECT' },
+  { label: 'FROM', insertText: 'FROM' },
+  { label: 'WHERE', insertText: 'WHERE' },
+  { label: 'JOIN', insertText: 'JOIN' },
+  { label: 'LEFT JOIN', insertText: 'LEFT JOIN' },
+  { label: 'INNER JOIN', insertText: 'INNER JOIN' },
+  { label: 'ORDER BY', insertText: 'ORDER BY' },
+  { label: 'GROUP BY', insertText: 'GROUP BY' },
+  { label: 'LIMIT', insertText: 'LIMIT' },
+  { label: 'INSERT', insertText: 'INSERT' },
+  { label: 'UPDATE', insertText: 'UPDATE' },
+  { label: 'DELETE', insertText: 'DELETE' },
+];


### PR DESCRIPTION
## Summary
- The `src/features/query/autocomplete/` directory was never committed — it appeared as untracked in git status
- `sql-autocomplete.ts` imports from these files, causing TypeScript build errors on all three CI platforms
- This adds the 5 missing files so the build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)